### PR TITLE
DM-15862: Reduce ISR code duplication between ip_isr, obs_subaru, and obs_decam

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -8,3 +8,5 @@ config.doLinearize = False
 config.doDefect = False
 config.doCrosstalk=True
 config.doAddDistortionModel = False
+config.qa.doThumbnailOss = False
+config.qa.doThumbnailFlattened = False

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -398,6 +398,11 @@ datasets:
     python: builtins.str
     storage: TextStorage
     template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d/compareVisit-v%(visit)d-%(description)s-%(style)s.png
+  # ISR stage thumbnails
+  ossThumb:
+    template: thumbs/%(visit)08d-%(filter)s/%(raftName)s/ossThumb_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.png
+  flattenedThumb:
+    template: thumbs/%(visit)08d-%(filter)s/%(raftName)s/flattenedThumb_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.png
 
   # Focal plane summary plots
   focal_plane_fits:


### PR DESCRIPTION


The lsstCamMapper has been updated to persist thumbnail images of the
overscan subtracted and flattened ISR images.  These thumbnails are
disabled by default in the config/isr.py file to prevent issues with
auxTel registries that do not contain the `raftName` column available
for phosim and imsim data.