### PR TITLE
rationalize handling of doCrosstalk for imsim and phosim

### DIFF
--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -20,4 +20,4 @@
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
-config.isr.doCrosstalk=False
+config.isr.doCrosstalk=True

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -1,0 +1,1 @@
+config.processCcd.isr.doCrosstalk=False

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -21,4 +21,4 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-config.processCcd.isr.doCrosstalk=False
+config.processCcd.isr.doCrosstalk=True

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -1,1 +1,24 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
 config.processCcd.isr.doCrosstalk=False

--- a/config/phosim/processCcd.py
+++ b/config/phosim/processCcd.py
@@ -1,1 +1,24 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
 config.isr.doCrosstalk=True

--- a/config/phosim/processCcd.py
+++ b/config/phosim/processCcd.py
@@ -1,0 +1,1 @@
+config.isr.doCrosstalk=True

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -1,0 +1,1 @@
+config.processCcd.isr.doCrosstalk=True

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -1,1 +1,24 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
 config.processCcd.isr.doCrosstalk=True


### PR DESCRIPTION
Handles both processCcd and singleFrameDriver
Tested both processCcd and singleFrameDriver using DESC imsim Run1.2i and Run1.2p repos:
`processCcd.py <pathtorepo> --rerun checkConfig --show config=isr.doCrosstalk`
This change should only impact imsim and phosim processing.