### PR TITLE
DM-17095: Speed up tests

### DIFF
--- a/python/lsst/obs/lsst/testHelper.py
+++ b/python/lsst/obs/lsst/testHelper.py
@@ -1,0 +1,61 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Test support classes for obs_lsst"""
+__all__ = ("ObsLsstButlerTests",)
+
+import os.path
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+
+# Define the data location relative to this package
+DATAROOT = os.path.join(getPackageDir("obs_lsst"), "data", "input")
+
+
+class ObsLsstButlerTests(lsst.utils.tests.TestCase):
+    """Base class shared by all tests of the butler and mapper.
+
+    This class can not inherit from `~lsst.obs.base.tests.ObsTests` since
+    that will trigger tests in this class directly that will fail.
+
+    This class defines a butler and a mapper for each test subclass.
+    They are stored in the ``_mapper`` and ``_butler`` class attributes
+    to distinguish them from the ``mapper`` and ``butler`` instance
+    attributes used by `~lsst.obs.base.tests.ObsTests`.
+    """
+
+    instrumentDir = "TBD"  # Override in subclass
+    """Name of instrument directory within data/input"""
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._mapper._LsstCamMapper__clearCache()
+        del cls._mapper
+        del cls._butler
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data_dir = os.path.normpath(os.path.join(DATAROOT, cls.instrumentDir))
+        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
+        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
+        mapper_class._LsstCamMapper__clearCache()
+        cls._mapper = mapper_class(root=cls.data_dir)

--- a/tests/test_auxTel.py
+++ b/tests/test_auxTel.py
@@ -24,28 +24,15 @@ import sys
 import unittest
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.afw.geom import arcseconds, Extent2I
 import lsst.afw.image
 import lsst.obs.base.tests
 
+from lsst.obs.lsst.testHelper import ObsLsstButlerTests
 
-class TestAuxTel(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        cls._mapper._LsstCamMapper__clearCache()
-        del cls._mapper
-        del cls._butler
 
-    @classmethod
-    def setUpClass(cls):
-        product_dir = getPackageDir('obs_lsst')
-        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'auxTel')
-
-        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
-        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        cls._mapper = mapper_class(root=cls.data_dir)
+class TestAuxTel(lsst.obs.base.tests.ObsTests, ObsLsstButlerTests):
+    instrumentDir = "auxTel"
 
     def setUp(self):
         dataIds = {'raw': {'visit': 5700065, 'detector': 0, 'dayObs': '2018-09-20', 'seqNum': 65},

--- a/tests/test_auxTel.py
+++ b/tests/test_auxTel.py
@@ -31,25 +31,29 @@ import lsst.obs.base.tests
 
 
 class TestAuxTel(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
-    def tearDown(self):
-        self.mapper._LsstCamMapper__clearCache()
-        super(TestAuxTel, self).tearDown()
+    @classmethod
+    def tearDownClass(cls):
+        cls._mapper._LsstCamMapper__clearCache()
+        del cls._mapper
+        del cls._butler
+
+    @classmethod
+    def setUpClass(cls):
+        product_dir = getPackageDir('obs_lsst')
+        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'auxTel')
+
+        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
+        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
+        mapper_class._LsstCamMapper__clearCache()
+        cls._mapper = mapper_class(root=cls.data_dir)
 
     def setUp(self):
-        product_dir = getPackageDir('obs_lsst')
-        data_dir = os.path.join(product_dir, 'data', 'input', 'auxTel')
-
-        butler = lsst.daf.persistence.Butler(root=data_dir)
-        mapper_class = butler.getMapperClass(root=data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        mapper = mapper_class(root=data_dir)
-
         dataIds = {'raw': {'visit': 5700065, 'detector': 0, 'dayObs': '2018-09-20', 'seqNum': 65},
                    'bias': {'detector': 0, 'dayObs': '2018-09-20', 'seqNum': 65},
                    'flat': unittest.SkipTest,
                    'dark': unittest.SkipTest
                    }
-        self.setUp_tests(butler, mapper, dataIds)
+        self.setUp_tests(self._butler, self._mapper, dataIds)
 
         ccdExposureId_bits = 32
         exposureIds = {'raw': 1140013000, 'bias': 1140013000}
@@ -80,7 +84,7 @@ class TestAuxTel(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                               linearizer_type=linearizer_type
                               )
 
-        path_to_raw = os.path.join(data_dir, "raw", "2018-09-20", "05700065-det000.fits")
+        path_to_raw = os.path.join(self.data_dir, "raw", "2018-09-20", "05700065-det000.fits")
         keys = set(('filter', 'patch', 'tract', 'visit', 'channel', 'amp', 'style', 'detector', 'dstype',
                     'calibDate', 'half', 'label', 'dayObs', 'run', 'snap', 'detectorName', 'raftName',
                     'numSubfilters', 'fgcmcycle', 'name', 'pixel_id', 'description', 'subfilter'))
@@ -101,7 +105,7 @@ class TestAuxTel(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                       ('filter', set(['visit', 'detector', 'dayObs'])),
                       ('visit', set(['visit', 'detector', 'dayObs']))
                       )
-        self.setUp_mapper(output=data_dir,
+        self.setUp_mapper(output=self.data_dir,
                           path_to_raw=path_to_raw,
                           keys=keys,
                           query_format=query_format,
@@ -123,7 +127,7 @@ class TestAuxTel(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                           plate_scale=20.0 * arcseconds,
                           )
 
-        super(TestAuxTel, self).setUp()
+        super().setUp()
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_imsim.py
+++ b/tests/test_imsim.py
@@ -24,28 +24,15 @@ import sys
 import unittest
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.afw.geom import arcseconds, Extent2I
 import lsst.afw.image
 import lsst.obs.base.tests
 
+from lsst.obs.lsst.testHelper import ObsLsstButlerTests
 
-class TestImsim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        cls._mapper._LsstCamMapper__clearCache()
-        del cls._mapper
-        del cls._butler
 
-    @classmethod
-    def setUpClass(cls):
-        product_dir = getPackageDir('obs_lsst')
-        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'imsim')
-
-        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
-        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        cls._mapper = mapper_class(root=cls.data_dir)
+class TestImsim(lsst.obs.base.tests.ObsTests, ObsLsstButlerTests):
+    instrumentDir = "imsim"
 
     def setUp(self):
         dataIds = {'raw': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11'},

--- a/tests/test_imsim.py
+++ b/tests/test_imsim.py
@@ -31,25 +31,29 @@ import lsst.obs.base.tests
 
 
 class TestImsim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
-    def tearDown(self):
-        self.mapper._LsstCamMapper__clearCache()
-        super(TestImsim, self).tearDown()
+    @classmethod
+    def tearDownClass(cls):
+        cls._mapper._LsstCamMapper__clearCache()
+        del cls._mapper
+        del cls._butler
+
+    @classmethod
+    def setUpClass(cls):
+        product_dir = getPackageDir('obs_lsst')
+        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'imsim')
+
+        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
+        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
+        mapper_class._LsstCamMapper__clearCache()
+        cls._mapper = mapper_class(root=cls.data_dir)
 
     def setUp(self):
-        product_dir = getPackageDir('obs_lsst')
-        data_dir = os.path.join(product_dir, 'data', 'input', 'imsim')
-
-        butler = lsst.daf.persistence.Butler(root=data_dir)
-        mapper_class = butler.getMapperClass(root=data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        mapper = mapper_class(root=data_dir)
-
         dataIds = {'raw': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11'},
                    'bias': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11'},
                    'flat': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11', 'filter': 'i'},
                    'dark': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11'}
                    }
-        self.setUp_tests(butler, mapper, dataIds)
+        self.setUp_tests(self._butler, self._mapper, dataIds)
 
         ccdExposureId_bits = 32
         exposureIds = {'raw': 40919042,
@@ -107,7 +111,7 @@ class TestImsim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                               linearizer_type=linearizer_type
                               )
 
-        path_to_raw = os.path.join(data_dir, "raw", "204595", "R11", "00204595-R11-S20-det042-000.fits")
+        path_to_raw = os.path.join(self.data_dir, "raw", "204595", "R11", "00204595-R11-S20-det042-000.fits")
         keys = set(('filter', 'patch', 'tract', 'visit', 'channel', 'amp', 'style', 'detector', 'dstype',
                     'snap', 'run', 'calibDate', 'half', 'detectorName', 'raftName', 'label',
                     'numSubfilters', 'fgcmcycle', 'name', 'pixel_id', 'description', 'subfilter'))
@@ -127,7 +131,7 @@ class TestImsim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                       ('filter', set(['visit', 'detector', 'snap', 'run', 'detectorName', 'raftName'])),
                       ('visit', set(['visit', 'detector', 'snap', 'run', 'detectorName', 'raftName']))
                       )
-        self.setUp_mapper(output=data_dir,
+        self.setUp_mapper(output=self.data_dir,
                           path_to_raw=path_to_raw,
                           keys=keys,
                           query_format=query_format,
@@ -149,7 +153,7 @@ class TestImsim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                           plate_scale=20.0 * arcseconds,
                           )
 
-        super(TestImsim, self).setUp()
+        super().setUp()
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_phosim.py
+++ b/tests/test_phosim.py
@@ -24,29 +24,15 @@ import sys
 import unittest
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.afw.geom import arcseconds, Extent2I
 import lsst.afw.image
 import lsst.obs.base.tests
 
+from lsst.obs.lsst.testHelper import ObsLsstButlerTests
 
-class TestPhosim(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._mapper._LsstCamMapper__clearCache()
-        del cls._mapper
-        del cls._butler
-
-    @classmethod
-    def setUpClass(cls):
-        product_dir = getPackageDir('obs_lsst')
-        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'phosim')
-
-        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
-        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        cls._mapper = mapper_class(root=cls.data_dir)
+class TestPhosim(lsst.obs.base.tests.ObsTests, ObsLsstButlerTests):
+    instrumentDir = "phosim"
 
     def setUp(self):
         dataIds = {'raw': {'visit': 204595, 'detectorName': 'S20', 'raftName': 'R11'},

--- a/tests/test_ts8.py
+++ b/tests/test_ts8.py
@@ -24,30 +24,16 @@ import sys
 import unittest
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.afw.geom import arcseconds, Extent2I
 import lsst.afw.image
 import lsst.obs.base.tests
 import lsst.obs.lsst
 
+from lsst.obs.lsst.testHelper import ObsLsstButlerTests
 
-class TestTs8(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._mapper._LsstCamMapper__clearCache()
-        del cls._mapper
-        del cls._butler
-
-    @classmethod
-    def setUpClass(cls):
-        product_dir = getPackageDir('obs_lsst')
-        cls.data_dir = os.path.join(product_dir, 'data', 'input', 'ts8')
-
-        cls._butler = lsst.daf.persistence.Butler(root=cls.data_dir)
-        mapper_class = cls._butler.getMapperClass(root=cls.data_dir)
-        mapper_class._LsstCamMapper__clearCache()
-        cls._mapper = mapper_class(root=cls.data_dir)
+class TestTs8(lsst.obs.base.tests.ObsTests, ObsLsstButlerTests):
+    instrumentDir = "ts8"
 
     def setUp(self):
         dataIds = {'raw': {'visit': 270095325, 'detectorName': 'S11'},


### PR DESCRIPTION
Creating a butler seems to take "forever" and we are doing it every test. This PR creates a butler ever test class. Tests now take 3 minutes rather than 15 minutes on my laptop.