### PR TITLE
Fix typo in LsstCamMapper

### DIFF
--- a/python/lsst/obs/lsst/lsstCamMapper.py
+++ b/python/lsst/obs/lsst/lsstCamMapper.py
@@ -207,7 +207,7 @@ class LsstCamMapper(CameraMapper):
     """
 
     packageName = 'obs_lsst'
-    _cameraName = "lsst"
+    _cameraName = "lsstCam"
     yamlFileList = ("lsstCamMapper.yaml",)  # list of yaml files to load, keeping the first occurrence
     #
     # do not set MakeRawVisitInfoClass or translatorClass to anything other


### PR DESCRIPTION
This one line change does not allow the default mapper class to be constructed, but it at least removes the file not found error.