### PR TITLE
DM-17766: PR 73 broke obs_lsst for calib construction

### DIFF
--- a/config/bias.py
+++ b/config/bias.py
@@ -23,4 +23,4 @@
 import os.path
 from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))

--- a/config/dark.py
+++ b/config/dark.py
@@ -23,6 +23,6 @@
 import os.path
 from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
 
 #config.repair.cosmicray.nCrPixelMax = 100000

--- a/config/flat.py
+++ b/config/flat.py
@@ -23,4 +23,4 @@
 import os.path
 from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))


### PR DESCRIPTION
Change config.load to config.isr.load in bias.py, dark.py, flat.py (in config directory). 