### PR TITLE
DM-17875: DESC config updates for DC2 stars only refererence catalog

### DIFF
--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -22,7 +22,4 @@
 
 config.isr.doCrosstalk=True
 
-# set SIP order fitting to 2 to avoid bad astrometric solutions
-config.calibrate.astrometry.wcsFitter.order=2
-
 config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -21,3 +21,8 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.isr.doCrosstalk=True
+
+# set SIP order fitting to 2 to avoid bad astrometric solutions
+config.calibrate.astrometry.wcsFitter.order=2
+
+config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -21,5 +21,3 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.isr.doCrosstalk=True
-
-config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -61,7 +61,6 @@ for refObjLoader in (config.charImage.refObjLoader,
                      config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader):
     refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-#    refObjLoader.load(os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py'))
     refObjLoader.ref_dataset_name='cal_ref_cat'
 
 # Better astrometry matching
@@ -82,7 +81,6 @@ config.calibrate.photoCal.applyColorTerms = False
 #colors["g-r"] = ColorLimit(primary="g_flux", secondary="r_flux", minimum=0.0)
 #colors["r-i"] = ColorLimit(primary="r_flux", secondary="i_flux", maximum=0.5)
 config.calibrate.photoCal.match.referenceSelection.doMagLimit = True
-#config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_i_smeared_flux"
 config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"
 config.calibrate.photoCal.match.referenceSelection.magLimit.maximum = 22.0
 # select only stars for photometry calibration

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -61,7 +61,7 @@ for refObjLoader in (config.charImage.refObjLoader,
                      config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader):
     refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-    refObjLoader.load(os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py'))
+#    refObjLoader.load(os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py'))
     refObjLoader.ref_dataset_name='cal_ref_cat'
 
 # Better astrometry matching
@@ -79,7 +79,8 @@ config.calibrate.photoCal.applyColorTerms = False
 #colors["g-r"] = ColorLimit(primary="g_flux", secondary="r_flux", minimum=0.0)
 #colors["r-i"] = ColorLimit(primary="r_flux", secondary="i_flux", maximum=0.5)
 config.calibrate.photoCal.match.referenceSelection.doMagLimit = True
-config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_i_smeared_flux"
+#config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_i_smeared_flux"
+config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"
 config.calibrate.photoCal.match.referenceSelection.magLimit.maximum = 22.0
 # select only stars for photometry calibration
 config.calibrate.photoCal.match.sourceSelection.unresolved.maximum=0.5

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -61,14 +61,12 @@ for refObjLoader in (config.charImage.refObjLoader,
                      config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader):
     refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+    refObjLoader.load(os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py'))
     refObjLoader.ref_dataset_name='cal_ref_cat'
 
 # Better astrometry matching
 # commented out for now
 #config.calibrate.astrometry.matcher.numBrightStars = 150
-
-# set SIP order fitting to 2 to avoid bad astrometric solutions
-config.calibrate.astrometry.wcsFitter.order=2
 
 # Set to match defaults currenyly used in HSC production runs (e.g. S15B)
 config.charImage.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
@@ -81,7 +79,7 @@ config.calibrate.photoCal.applyColorTerms = False
 #colors["g-r"] = ColorLimit(primary="g_flux", secondary="r_flux", minimum=0.0)
 #colors["r-i"] = ColorLimit(primary="r_flux", secondary="i_flux", maximum=0.5)
 config.calibrate.photoCal.match.referenceSelection.doMagLimit = True
-config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"
+config.calibrate.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_i_smeared_flux"
 config.calibrate.photoCal.match.referenceSelection.magLimit.maximum = 22.0
 # select only stars for photometry calibration
 config.calibrate.photoCal.match.sourceSelection.unresolved.maximum=0.5

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -68,6 +68,9 @@ for refObjLoader in (config.charImage.refObjLoader,
 # commented out for now
 #config.calibrate.astrometry.matcher.numBrightStars = 150
 
+# set SIP order fitting to 2 to avoid bad astrometric solutions
+config.calibrate.astrometry.wcsFitter.order=2
+
 # Set to match defaults currenyly used in HSC production runs (e.g. S15B)
 config.charImage.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
 config.calibrate.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95

--- a/policy/cameraHeader.yaml
+++ b/policy/cameraHeader.yaml
@@ -54,13 +54,13 @@ AMP_E2V : &AMP_E2V                      # N.b. the assembly of E2V amps into a C
     #v_overscan : 46                     # number of overscan pixel in y (parallel)
     #v_overscan0 : 0                     # first overscan pixel in y (parallel)
 
-    saturation : 56000                  # saturation level, DN XXX Should this be in electrons?
+    saturation : 142857                  # saturation level, DN XXX Should this be in electrons?
 
     # Linearity correction is still under discussion, so this is a placeholder.
     linearityType : PROPORTIONAL
     linearityThreshold : 0
-    linearityMax : 65535                # == saturation
-    linearityCoeffs : [0, 65535]        # == [linearityThreshold, linearityMax]
+    linearityMax : 142857                # == saturation
+    linearityCoeffs : [0, 142857]        # == [linearityThreshold, linearityMax]
 
 AMP_ITL : &AMP_ITL
     perAmpData : True                   # data is provided independentally for each amplifier
@@ -76,14 +76,14 @@ AMP_ITL : &AMP_ITL
     rawParallelPrescanBBox  : [[0,    1], [0,         0]]  # pixels digitised before first parallel transfer
     rawParallelOverscanBBox : [[3, 2000], [509,      48]]  # parallel overscan
 
-    saturation : 56000                  # saturation level, DN XXX Should this be in electrons?
+    saturation : 142857                  # saturation level, DN XXX Should this be in electrons?
 
     # Linearity correction is still under discussion, so this is a placeholder.
     linearityType : PROPORTIONAL
     linearityThreshold : 0
-    linearityMax : 65535                # == saturation
-    linearityCoeffs : [0, 65535]        # == [linearityThreshold, linearityMax]
-
+    linearityMax : 142857                # == saturation
+    linearityCoeffs : [0, 142857]        # == [linearityThreshold, linearityMax]
+  
 #
 # A single CCD ("sensor" to the camera team)
 #

--- a/policy/cameraHeader.yaml
+++ b/policy/cameraHeader.yaml
@@ -83,7 +83,7 @@ AMP_ITL : &AMP_ITL
     linearityThreshold : 0
     linearityMax : 142857                # == saturation
     linearityCoeffs : [0, 142857]        # == [linearityThreshold, linearityMax]
-  
+
 #
 # A single CCD ("sensor" to the camera team)
 #


### PR DESCRIPTION
As agreed at this week's DM-DC2 meeting, we want to merge the config changes from the u/jchiang/run2.xi_stars_only_ref_cats branch into master for use as part of the DC2 Run2.1i processing which will use a star-only reference catalog.

Opening the PR, but would like some guidance on what testing is required by the reviewers @RobertLuptonTheGood @timj  I don't think I can start up a Jenkins stack-os-matrix Job - is that something I should request a DM person to do?

@jchiang87 I think I cherry-picked your 2 commits properly, but please take a peek to make sure.