### PR TITLE
DM-17903: Ensure that ccdKeys is set

### DIFF
--- a/config/bias.py
+++ b/config/bias.py
@@ -23,4 +23,5 @@
 import os.path
 from lsst.utils import getPackageDir
 
+config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
 config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))

--- a/config/dark.py
+++ b/config/dark.py
@@ -23,6 +23,7 @@
 import os.path
 from lsst.utils import getPackageDir
 
+config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
 config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
 
 #config.repair.cosmicray.nCrPixelMax = 100000

--- a/config/flat.py
+++ b/config/flat.py
@@ -23,4 +23,5 @@
 import os.path
 from lsst.utils import getPackageDir
 
+config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
 config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))

--- a/config/lsstCamCommon.py
+++ b/config/lsstCamCommon.py
@@ -21,12 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 """
-LSST Cam-specific overrides for IsrTask
+LSST Cam generic settings
 """
-
-config.doLinearize = False
-config.doDefect = False
-config.doCrosstalk=True
-config.doAddDistortionModel = False
-config.qa.doThumbnailOss = False
-config.qa.doThumbnailFlattened = False
+if hasattr(config, 'ccdKeys'):
+    config.ccdKeys = ['detector', 'snap', 'raftName', 'detectorName']

--- a/config/sky.py
+++ b/config/sky.py
@@ -28,10 +28,11 @@ from lsst.utils import getPackageDir
 #from lsst.obs.lsst.isr import SubaruIsrTask
 #config.isr.retarget(SubaruIsrTask)
 #config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
-
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
-
 configDir = os.path.join(getPackageDir("obs_lsst"), "config")
+
+config.load(os.path.join(configDir, "lsstCamCommon.py"))
+config.isr.load(os.path.join(configDir, "isr.py"))
+
 bgFile = os.path.join(configDir, "background.py")
 fpBgFile = os.path.join(configDir, "focalPlaneBackground.py")
 


### PR DESCRIPTION
#73 wasn't quite correct. It ended up setting the ccdKeys in config.isr rather than the root config. This broke imsim ci_lsst.  With this change I reintroduce a generic lsstCamCommon configuration that defines ccdKeys.