### PR TITLE
add snap to unique keys for PhoSim ingest

### DIFF
--- a/config/phosim/ingest.py
+++ b/config/phosim/ingest.py
@@ -23,3 +23,5 @@
 from lsst.obs.lsst.phosim import PhosimParseTask
 
 config.parse.retarget(PhosimParseTask)
+config.register.visit = list(config.register.columns.keys())
+config.register.unique = ["visit", "detector","snap"]


### PR DESCRIPTION
Before this change we ran into the following issue when trying to ingest PhoSim images where multiple exposures corresponded to one visit:

```
(lsst-scipipe-fcd27eb) [dthomas@rhea ingestBug]$ ls 
lsst_a_9000000_f1_R04_S20_E000.fits lsst_a_9000000_f1_R04_S20_E001.fits _mapper
(lsst-scipipe-fcd27eb) [dthomas@rhea ingestBug]$ ingestImages.py . *.fits 
....
ingest WARN: lsst_a_9000000_f1_R04_S20_E001.fits: already ingested: {'testType': 'PHOSIM', 'expTime': 15.0, 'object': 'UNKNOWN', 'imageType': 'SKYEXP', 'filter': 'g', 'lsstSerial': 'R04_S20_C0', 'date': '2021-12-04T07:12:01.500', 'dateObs': '2021-12-04T07:12:01.500', 'run': '9000000', 'visit': 9000000, 'wavelength': -666, 'raftName': 'R04', 'detectorName': 'S20', 'detector': 204, 'snap': 1}
Traceback (most recent call last):
  File "/home/dthomas/lsst16/stack/miniconda3-4.5.4-fcd27eb/Linux64/pipe_tasks/16.0-70-g8e97068c+5/bin/ingestImages.py", line 3, in <module>
    IngestTask.parseAndRun()
  File "/home/dthomas/lsst16/stack/miniconda3-4.5.4-fcd27eb/Linux64/pipe_tasks/16.0-70-g8e97068c+5/python/lsst/pipe/tasks/ingest.py", line 395, in parseAndRun
    task.run(args)
  File "/home/dthomas/lsst16/stack/miniconda3-4.5.4-fcd27eb/Linux64/pipe_tasks/16.0-70-g8e97068c+5/python/lsst/pipe/tasks/ingest.py", line 532, in run
    self.register.addRow(registry, info, dryrun=args.dryrun, create=args.create)
  File "/home/dthomas/lsst16/stack/miniconda3-4.5.4-fcd27eb/Linux64/pipe_tasks/16.0-70-g8e97068c+5/python/lsst/pipe/tasks/ingest.py", line 347, in addRow
    conn.cursor().execute(sql, values)
sqlite3.IntegrityError: UNIQUE constraint failed: raw.visit, raw.detector
...
(lsst-scipipe-fcd27eb) [dthomas@rhea ingestBug]$ sqlite3 registry.sqlite3boorf3bu
SQLite version 3.24.0 2018-06-04 19:24:41
Enter ".help" for usage hints.
sqlite> select * from raw;
1|9000000|9000000|g|2021-12-04T07:11:43.500|2021-12-04T07:11:43.500|15.0|R04|S20|204|0|UNKNOWN|SKYEXP|PHOSIM|R04_S20_C0|-666
```

After the change below the ingest adds snap to the unique keys, and the different exposures are successfully ingested:

```
(lsst-scipipe-fcd27eb) [dthomas@rhea ingestBug]$ sqlite3 registry.sqlite3
SQLite version 3.24.0 2018-06-04 19:24:41
Enter ".help" for usage hints.
sqlite> select * from raw;
1|9000000|9000000|g|2021-12-04T07:11:43.500|2021-12-04T07:11:43.500|15.0|R04|S20|204|0|UNKNOWN|SKYEXP|PHOSIM|R04_S20_C0|-666
2|9000000|9000000|g|2021-12-04T07:12:01.500|2021-12-04T07:12:01.500|15.0|R04|S20|204|1|UNKNOWN|SKYEXP|PHOSIM|R04_S20_C0|-666
```

All the unit tests still pass.