### PR TITLE
DM-18551: update ccdExposureId_bits

### DIFF
--- a/python/lsst/obs/lsst/imsim.py
+++ b/python/lsst/obs/lsst/imsim.py
@@ -39,6 +39,10 @@ class ImsimMapper(LsstCamMapper):
 
     _cameraName = "imsim"
 
+    def bypass_ccdExposureId_bits(self, datasetType, pythonType, location, dataId):
+        """How many bits are required for the maximum exposure ID"""
+        return 38  # max detector_exposure_id ~ 60000000205
+
 
 class ImsimParseTask(LsstCamParseTask):
     """Parser suitable for imsim data.

--- a/python/lsst/obs/lsst/phosim.py
+++ b/python/lsst/obs/lsst/phosim.py
@@ -39,6 +39,10 @@ class PhosimMapper(LsstCamMapper):
 
     _cameraName = "phosim"
 
+    def bypass_ccdExposureId_bits(self, datasetType, pythonType, location, dataId):
+        """How many bits are required for the maximum exposure ID"""
+        return 38  # max detector_exposure_id ~ 60000000205
+
 
 class PhosimParseTask(LsstCamParseTask):
     """Parser suitable for phosim data.

--- a/tests/test_imsim.py
+++ b/tests/test_imsim.py
@@ -41,7 +41,7 @@ class TestImsim(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
                    }
         self.setUp_tests(self._butler, self._mapper, dataIds)
 
-        ccdExposureId_bits = 51
+        ccdExposureId_bits = 38
         exposureIds = {'raw': 204595042,
                        'bias': 204595042,
                        'dark': 204595042,

--- a/tests/test_phosim.py
+++ b/tests/test_phosim.py
@@ -41,7 +41,7 @@ class TestPhosim(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
                    }
         self.setUp_tests(self._butler, self._mapper, dataIds)
 
-        ccdExposureId_bits = 51
+        ccdExposureId_bits = 38
         exposureIds = {'raw': 204595042}
         filters = {'raw': 'i'}
         exptimes = {'raw': 30.0}


### PR DESCRIPTION
As discussed on SLACK: https://lsstc.slack.com/archives/CBE964PR8/p1552065738002400 ccdExposureId_bits has been set to 38 for both imSim and phoSim.  DESC needs this update for the upcoming DC2 Run2.1i processing.