### PR TITLE
Updating configs for star+galaxy ref cats

### DIFF
--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -21,3 +21,10 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.isr.doCrosstalk=True
+
+# Additional configs for star+galaxy ref cats now that DM-17917 is merged
+config.calibrate.astrometry.referenceSelection.doUnresolved = True
+config.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
+config.calibrate.astrometry.referenceSelection.unresolved.minimum = None
+config.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -22,3 +22,11 @@
 #
 
 config.processCcd.isr.doCrosstalk=True
+
+
+# Additional configs for star+galaxy ref cats now that DM-17917 is merged
+config.processCcd.calibrate.astrometry.referenceSelection.doUnresolved = True
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.minimum = None
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+

--- a/config/phosim/processCcd.py
+++ b/config/phosim/processCcd.py
@@ -22,3 +22,10 @@
 #
 
 config.isr.doCrosstalk=True
+
+# Additional configs for star+galaxy ref cats now that DM-17917 is merged
+config.calibrate.astrometry.referenceSelection.doUnresolved = True
+config.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
+config.calibrate.astrometry.referenceSelection.unresolved.minimum = None
+config.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -22,3 +22,10 @@
 #
 
 config.processCcd.isr.doCrosstalk=True
+
+# Additional configs for star+galaxy ref cats now that DM-17917 is merged
+config.processCcd.calibrate.astrometry.referenceSelection.doUnresolved = True
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.minimum = None
+config.processCcd.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+


### PR DESCRIPTION
As mentioned on Slack https://lsstc.slack.com/archives/C978LTJGN/p1550252025011800 since DM-17917 there is now the option to select "unresolved" sources in reference catalogs for astrometry matching.  DESC DC2 Run2.1i will be using a reference catalog that has stars + galaxies. This PR adds the configs necessary to imSim and phoSim processCcd processing to utilize this feature.