### PR TITLE
DM-18746: Remove list of CALIB tables from ingestCalib.py and use the default to avoid omitting sky table

### DIFF
--- a/config/ingestCalibs.py
+++ b/config/ingestCalibs.py
@@ -42,5 +42,4 @@ config.parse.translators = {'detector': 'translate_detector',
                             }
 
 config.register.unique = ['filter', 'detector', 'calibDate']
-config.register.tables = ['bias', 'dark', 'flat', 'fringe']
 config.register.visit = ['calibDate', 'filter']


### PR DESCRIPTION
It was discovered that we are overriding the default list of CALIB tables and have omitted the sky table.  To avoid this in the future, we will remove this one line from `config/ingestCalib.py`, as discussed on the dm-lsstcam channel: https://lsstc.slack.com/archives/CBE964PR8/p1554124198054300


