### PR TITLE
DM-18643: Rename referenceSelection to referenceSelector and change default field to "resolved"

### DIFF
--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -23,8 +23,8 @@
 config.isr.doCrosstalk=True
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.calibrate.astrometry.referenceSelection.doUnresolved = True
-config.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
-config.calibrate.astrometry.referenceSelection.unresolved.minimum = None
-config.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+config.calibrate.astrometry.referenceSelector.doUnresolved = True
+config.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
+config.calibrate.astrometry.referenceSelector.unresolved.minimum = None
+config.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -25,8 +25,8 @@ config.processCcd.isr.doCrosstalk=True
 
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.processCcd.calibrate.astrometry.referenceSelection.doUnresolved = True
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.minimum = None
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+config.processCcd.calibrate.astrometry.referenceSelector.doUnresolved = True
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.minimum = None
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -21,12 +21,9 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-config.processCcd.isr.doCrosstalk=True
+import os.path
 
+from lsst.utils import getPackageDir
 
-# Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.processCcd.calibrate.astrometry.referenceSelector.doUnresolved = True
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.minimum = None
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
-
+config.processCcd.load(os.path.join(getPackageDir("obs_lsst"), "config",
+                                    "imsim", "processCcd.py"))

--- a/config/phosim/processCcd.py
+++ b/config/phosim/processCcd.py
@@ -24,8 +24,8 @@
 config.isr.doCrosstalk=True
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.calibrate.astrometry.referenceSelection.doUnresolved = True
-config.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
-config.calibrate.astrometry.referenceSelection.unresolved.minimum = None
-config.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+config.calibrate.astrometry.referenceSelector.doUnresolved = True
+config.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
+config.calibrate.astrometry.referenceSelector.unresolved.minimum = None
+config.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -24,8 +24,8 @@
 config.processCcd.isr.doCrosstalk=True
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.processCcd.calibrate.astrometry.referenceSelection.doUnresolved = True
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.name = 'isresolved'
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.minimum = None
-config.processCcd.calibrate.astrometry.referenceSelection.unresolved.maximum = 0.5
+config.processCcd.calibrate.astrometry.referenceSelector.doUnresolved = True
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.minimum = None
+config.processCcd.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -21,11 +21,9 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-config.processCcd.isr.doCrosstalk=True
+import os.path
 
-# Additional configs for star+galaxy ref cats now that DM-17917 is merged
-config.processCcd.calibrate.astrometry.referenceSelector.doUnresolved = True
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.minimum = None
-config.processCcd.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
+from lsst.utils import getPackageDir
 
+config.processCcd.load(os.path.join(getPackageDir("obs_lsst"), "config",
+                                    "phosim", "processCcd.py"))


### PR DESCRIPTION
The field was called "isresolved" previously due to a miscommunication.  This
has been fixed at the same time as updating the config parameter name.