### PR TITLE
DM-19218: set doCrosstalkBeforeAssemble to False

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -27,6 +27,7 @@ LSST Cam-specific overrides for IsrTask
 config.doLinearize = False
 config.doDefect = False
 config.doCrosstalk=True
+config.doCrosstalkBeforeAssemble = False
 config.doAddDistortionModel = False
 config.qa.doThumbnailOss = False
 config.qa.doThumbnailFlattened = False


### PR DESCRIPTION
For DESC DC2 processing, we need to include `config.doCrosstalkBeforeAssemble = False`.  This has been added to config/isr.py, assuming this is the correct setting for all users of obs_lsst.