### PR TITLE
DM-19570: Skip the raw_sub test from obs_base

### DIFF
--- a/python/lsst/obs/lsst/testHelper.py
+++ b/python/lsst/obs/lsst/testHelper.py
@@ -71,6 +71,10 @@ class ObsLsstButlerTests(lsst.utils.tests.TestCase):
 class ObsLsstObsBaseOverrides(lsst.obs.base.tests.ObsTests):
     """Specialist butler tests for obs_lsst."""
 
+    @unittest.skip("raw_sub not supported bt obs_lsst")
+    def test_raw_sub_bbox(self):
+        return
+
     def testRawVisitInfo(self):
         visitInfo = self.butler.get("raw_visitInfo", self.dataIds["raw"])
         self.assertIsInstance(visitInfo, lsst.afw.image.VisitInfo)


### PR DESCRIPTION
raw_sub does not work with obs_lsst package.