### PR TITLE
DM-19382: Add dataset for preinterp ISR exp.

### DIFF
--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -35,6 +35,8 @@ exposures:
     template: raw/%(run)s/%(raftName)s/%(visit)08d-%(raftName)s-%(detectorName)s-det%(detector)03d-%(snap)03d.fits[%(channel)d]
   postISRCCD:
     template: postISRCCD/%(visit)08d-%(filter)s/%(raftName)s/postISRCCD_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+  postISRCCD_uninterpolated:
+    template: postISRCCD/%(visit)08d-%(filter)s/%(raftName)s/postISRCCD_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d-preInterp.fits
   calexp:
     template: calexp/%(visit)08d-%(filter)s/%(raftName)s/calexp_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   icExp:


### PR DESCRIPTION
Previously, masking and interpolation was done on a by-defect-type
basis: a set of bad pixels were masked and interpolated, then the
process repeated on different bad pixels. However, this ignores the
case where different types of bad pixels may be contiguous, resulting
in interpolated pixels being derived based on previously interpolated
values.

The new dataset needs a template for the data to be saved.