### PR TITLE
DM-20524: Add some fixes for DIA analysis

### DIFF
--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -277,17 +277,17 @@ datasets:
     tables: raw
     template: ignored
   dcrDiff_diaSrc:
-    template: dcrDiff/v%(visit)d-f%(filter)s/%(raftName)s/diaSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: dcrDiff/v%(visit)08d-f%(filter)s/%(raftName)s/diaSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   dcrDiff_kernelSrc:
-    template: dcrDiff/v%(visit)d-f%(filter)s/%(raftName)s/kernelSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: dcrDiff/v%(visit)08d-f%(filter)s/%(raftName)s/kernelSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   dcrDiff_metadata:
-    template: dcrDiff/v%(visit)d-f%(filter)s/%(raftName)s/metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
+    template: dcrDiff/v%(visit)08d-f%(filter)s/%(raftName)s/metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
   deepDiff_diaSrc:
-    template: deepDiff/v%(visit)d-f%(filter)s/%(raftName)s/diaSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: deepDiff/v%(visit)08d-f%(filter)s/%(raftName)s/diaSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   deepDiff_kernelSrc:
-    template: deepDiff/v%(visit)d-f%(filter)s/%(raftName)s/kernelSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: deepDiff/v%(visit)08d-f%(filter)s/%(raftName)s/kernelSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   deepDiff_metadata:
-    template: deepDiff/v%(visit)d-f%(filter)s/%(raftName)s/metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
+    template: deepDiff/v%(visit)08d-f%(filter)s/%(raftName)s/metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
   forced_metadata:
     persistable: PropertySet
     python: lsst.daf.base.PropertySet

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -77,7 +77,6 @@ exposures:
   dcrDiff_matchedExp:
     template: dcrDiff/v%(visit)08d-f%(filter)s/%(raftName)s/matchexp_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
 
-
 calibrations:
   defects:
     columns:
@@ -440,6 +439,82 @@ datasets:
     template: thumbs/%(visit)08d-%(filter)s/%(raftName)s/ossThumb_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.png
   flattenedThumb:
     template: thumbs/%(visit)08d-%(filter)s/%(raftName)s/flattenedThumb_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.png
+  # Difference image products
+  deepDiff_diaObject:
+    description: "Catalog of combined diaSrc objects."
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: deepDiff/diaObject/%(tract)d/%(patch)s/diaObject-%(tract)d-%(patch)s.fits
+  deepDiff_diaObject_schema:
+    description: "Catalog of diaObjects"
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: schema/deepDiff_diaObject.fits
+  deepDiff_forced_diaSrc:
+    description: "Catalog of forced measurements (shape and position parameters held fixed) on the difference images."
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: deepDiff/v%(visit)08d-f%(filter)s/%(raftName)s/diaForced_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    tables: 'raw'
+  deepDiff_forced_diaSrc_schema:
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: schema/deepDiff_forced_dia_src.fits
+  deepDiff_forced_diaObject:
+    description: "Catalog of forced measurements (shape and position parameters held fixed) on the templates."
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: deepDiff/%(filter)s/%(tract)d/%(patch)s/diaObject-%(filter)s-%(tract)d-%(patch)s.fits
+  deepDiff_forced_diaObject_schema:
+    persistable: SourceCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.SourceCatalog
+    template: schema/deepDiff_forced_dia_object.fits
+  imageDifferenceDriver_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.imageDifferenceDriver.ImageDifferenceDriverConfig
+    template: config/imageDifferenceDriver.py
+  imageDifferenceDriver_metadata:
+    persistable: PropertySet
+    python: lsst.daf.base.PropertySet
+    storage: BoostStorage
+    tables:
+    - raw
+    - raw_visit
+    template: '%(pointing)05d/%(filter)s/imageDifferenceDriver_metadata/%(visit)07d.boost'
+  associationDriver_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.associationDriver.associationDriverConfig
+    template: config/associationDriver.py
+  forcedPhotCcdDiaDriver_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.forcedPhotCcdDiaDriver.ForcedPhotCcdDiaDriverConfig
+    template: config/forcedPhotCcdDiaDriver.py
+  forcedPhotCoaddDiaDriver_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.forcedPhotCoaddDiaDriver.ForcedPhotCoaddDiaDriverConfig
+    template: config/forcedPhotCoaddDiaDriver.py
+  forcedPhotCcdDia_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.forcedPhotDia.ForcedPhotCcdDiaDriverConfig
+    template: config/forcedPhotCcdDiaDriver.py
+  forcedPhotCoaddDia_config:
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.dia.pipe.forcedPhotDia.ForcedPhotCoaddDiaConfig
+    template: config/forcedPhotCoaddDia.py
+  forcedPhotCcd_metadata:
+    template: '%(pointing)05d/%(filter)s/tract%(tract)d/forcedPhotCcd_metadata/%(visit)07d-%(ccd)03d.yaml'
 
   # Focal plane summary plots
   focal_plane_fits:

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -475,6 +475,12 @@ datasets:
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
     template: schema/deepDiff_forced_dia_object.fits
+  deepDiff_diaObjectId:
+    description: "Catalog of diaSrc ids for each diaObject"
+    template: deepDiff/diaObject/%(tract)d/%(patch)s/diaObjectId-%(tract)d-%(patch)s.parq
+    persistable: ignored
+    storage: ParquetStorage
+    python: lsst.dia.pipe.parqueTable.ParquetTable
   imageDifferenceDriver_config:
     persistable: Config
     storage: ConfigStorage

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -483,11 +483,11 @@ datasets:
   imageDifferenceDriver_metadata:
     persistable: PropertySet
     python: lsst.daf.base.PropertySet
-    storage: BoostStorage
+    storage: YamlStorage
     tables:
     - raw
     - raw_visit
-    template: '%(pointing)05d/%(filter)s/imageDifferenceDriver_metadata/%(visit)07d.boost'
+    template: imageDifferenceDriver_metadata/%(visit)08d-%(filter)s/%(tract)d/%(patch)s/imageDifferenceDriverMetadata_%(visit)08d-%(filter)s-%(raftName)-%(detectorName)s-det%(detector)03d.yaml
   associationDriver_config:
     persistable: Config
     storage: ConfigStorage
@@ -513,8 +513,6 @@ datasets:
     storage: ConfigStorage
     python: lsst.dia.pipe.forcedPhotDia.ForcedPhotCoaddDiaConfig
     template: config/forcedPhotCoaddDia.py
-  forcedPhotCcd_metadata:
-    template: '%(pointing)05d/%(filter)s/tract%(tract)d/forcedPhotCcd_metadata/%(visit)07d-%(ccd)03d.yaml'
 
   # Focal plane summary plots
   focal_plane_fits:


### PR DESCRIPTION
1. Correct `{dcr,deep}Diff_*` visit format strings to explicitly be `%(visit)08d`
2. Add `deepDiff_diaObject`, `deepDiff_forced_diaSrc`, `deepDiff_forced_diaObject`,  `deepDiff_diaObjectId` and accompanying `_schema` dataset types.
3. Adds configs for additional Tasks to support DIA analysis.  
_NOTE_ that these are configs used by `LSSTDESC/dia_pipe`.  While `LSSTDESC/dia_pipe` is not in the main LSST code base, I hope that we can help develop our way toward very similar things being incorporated in LSST repos -- likely eventually in pipe_tasks.
 `forcedPhotCcdDiaDriver_config`, `forcedPhotCoaddDiaDriver_config`, `forcedPhotCcdDia_config`, `forcedPhotCoaddDia_config`, `imageDifferenceDriver_config`, `imageDifferenceDriver_metadata`, `associationDriver_config`.  