### PR TITLE
DM-21187: Ensure that latiss target depends on the latiss camera YAML

### DIFF
--- a/latiss/SConscript
+++ b/latiss/SConscript
@@ -23,3 +23,4 @@ command = (f"{python} {pipe_tasks_dir}/bin/ingestDefects.py latiss/CALIB/ {data_
            "--calib latiss/CALIB --config clobber=True")
 commandInst = env.Command('CALIB/calibRegistry.sqlite3', [], command)
 env.Depends(commandInst, lsst.sconsUtils.targets["python"])
+env.Depends(commandInst, "../policy/latiss.yaml")


### PR DESCRIPTION
Now that generateCamera is a bit slower to start up, there was a race between ingestDefects and generateCamera creating the latiss.yaml file. This changes adds an explicit dependency between the two.  I don't seem to be able to declare that `latiss` target depends on `policy` target.