### PR TITLE
Merge dc2/run2.1 DESC updates into new dc2/run2.2 branch

### DIFF
--- a/config/imsim/coaddDriver.py
+++ b/config/imsim/coaddDriver.py
@@ -1,0 +1,23 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+config.makeCoaddTempExp.doApplySkyCorr = True

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -28,3 +28,7 @@ config.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
 config.calibrate.astrometry.referenceSelector.unresolved.minimum = None
 config.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 
+# DM-17043 and DM-16785
+config.charImage.measurePsf.starSelector["objectSize"].doFluxLimit = False
+config.charImage.measurePsf.starSelector["objectSize"].doSignalToNoiseLimit = True
+config.charImage.measurePsf.starSelector["objectSize"].signalToNoiseMin = 20

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -33,3 +33,6 @@ config.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 config.charImage.measurePsf.starSelector["objectSize"].doFluxLimit = False
 config.charImage.measurePsf.starSelector["objectSize"].doSignalToNoiseLimit = True
 config.charImage.measurePsf.starSelector["objectSize"].signalToNoiseMin = 20
+
+# Discussed on Slack #desc-dm-dc2 with Lauren
+config.charImage.measurePsf.starSelector["objectSize"].signalToNoiseMax = 200

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -22,6 +22,7 @@
 
 config.isr.doCrosstalk=True
 config.isr.doBrighterFatter = True
+config.isr.doWrite = False
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
 config.calibrate.astrometry.referenceSelector.doUnresolved = True

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -21,6 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.isr.doCrosstalk=True
+config.isr.doBrighterFatter = True
 
 # Additional configs for star+galaxy ref cats now that DM-17917 is merged
 config.calibrate.astrometry.referenceSelector.doUnresolved = True

--- a/config/isr.py
+++ b/config/isr.py
@@ -30,3 +30,4 @@ config.doCrosstalk=True
 config.doAddDistortionModel = False
 config.qa.doThumbnailOss = False
 config.qa.doThumbnailFlattened = False
+config.doCrosstalkBeforeAssemble = False

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -283,6 +283,12 @@ datasets:
     storage: FitsCatalogStorage
     tables: raw
     template: forced/%(visit)08d-%(filter)s/%(raftName)s/forced_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+  forcedPhotCcd_metadata:
+    persistable: PropertySet
+    python: YamlStorage
+    storage: lsst.daf.base.PropertySet
+    tables: raw
+    template: forcedPhotCcd_metadata/%(visit)08d-%(filter)s/%(raftName)s/forcedPhotCcd_metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
   goodSeeingCoaddId:
     persistable: ignored
     python: lsst.daf.base.PropertySet


### PR DESCRIPTION
For DC2 Run2.2i, DESC is moving to use DM 18.1.0.  Merging in updates from our dc2/run2.1 branch into the new dc2/run2.2 branch which is based on 18.1.0