### PR TITLE
Apply S/N cuts on sources used for aperture correction and zp calculation

### DIFF
--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -30,6 +30,12 @@ config.calibrate.astrometry.referenceSelector.unresolved.name = 'resolved'
 config.calibrate.astrometry.referenceSelector.unresolved.minimum = None
 config.calibrate.astrometry.referenceSelector.unresolved.maximum = 0.5
 
+# Make sure galaxies are not used for zero-point calculation.
+config.calibrate.photoCal.match.referenceSelection.doUnresolved = True
+config.calibrate.photoCal.match.referenceSelection.unresolved.name = 'resolved'
+config.calibrate.photoCal.match.referenceSelection.unresolved.minimum = None
+config.calibrate.photoCal.match.referenceSelection.unresolved.maximum = 0.5
+
 # DM-17043 and DM-16785
 config.charImage.measurePsf.starSelector["objectSize"].doFluxLimit = False
 config.charImage.measurePsf.starSelector["objectSize"].doSignalToNoiseLimit = True

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -53,11 +53,11 @@ config.charImage.measureApCorr.sourceSelector['science'].flags.bad = []
 config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.minimum = 150.0
 config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.maximum = None
 config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.fluxField = 'base_PsfFlux_instFlux'
-config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.errField='base_PsfFlux_instFluxErr'
+config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.errField = 'base_PsfFlux_instFluxErr'
 config.charImage.measureApCorr.sourceSelector.name = 'science'
 
 # S/N cuts for zero-point calculation
 config.calibrate.photoCal.match.sourceSelection.doSignalToNoise = True
 config.calibrate.photoCal.match.sourceSelection.signalToNoise.minimum = 150
-config.calibrate.photoCal.match.sourceSelection.signalToNoise.fluxField='base_PsfFlux_instFlux'
-config.calibrate.photoCal.match.sourceSelection.signalToNoise.errField='base_PsfFlux_instFluxErr'
+config.calibrate.photoCal.match.sourceSelection.signalToNoise.fluxField = 'base_PsfFlux_instFlux'
+config.calibrate.photoCal.match.sourceSelection.signalToNoise.errField = 'base_PsfFlux_instFluxErr'

--- a/config/imsim/processCcd.py
+++ b/config/imsim/processCcd.py
@@ -38,3 +38,20 @@ config.charImage.measurePsf.starSelector["objectSize"].signalToNoiseMin = 20
 # Discussed on Slack #desc-dm-dc2 with Lauren and set to 200 for Run2.1i
 # For Run2.2i, setting to zero per https://github.com/LSSTDESC/ImageProcessingPipelines/issues/136
 config.charImage.measurePsf.starSelector["objectSize"].signalToNoiseMax = 0
+
+# S/N cuts for computing aperture corrections.
+config.charImage.measureApCorr.sourceSelector['science'].doFlags = True
+config.charImage.measureApCorr.sourceSelector['science'].doSignalToNoise = True
+config.charImage.measureApCorr.sourceSelector['science'].flags.good = ['calib_psf_used']
+config.charImage.measureApCorr.sourceSelector['science'].flags.bad = []
+config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.minimum = 150.0
+config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.maximum = None
+config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.fluxField = 'base_PsfFlux_instFlux'
+config.charImage.measureApCorr.sourceSelector['science'].signalToNoise.errField='base_PsfFlux_instFluxErr'
+config.charImage.measureApCorr.sourceSelector.name = 'science'
+
+# S/N cuts for zero-point calculation
+config.calibrate.photoCal.match.sourceSelection.doSignalToNoise = True
+config.calibrate.photoCal.match.sourceSelection.signalToNoise.minimum = 150
+config.calibrate.photoCal.match.sourceSelection.signalToNoise.fluxField='base_PsfFlux_instFlux'
+config.calibrate.photoCal.match.sourceSelection.signalToNoise.errField='base_PsfFlux_instFluxErr'


### PR DESCRIPTION
Also restrict to point sources for reference catalog selection for zp calculation.