### PR TITLE
DM-23278: Clear RASTART etc headers taken before Feb 2020

### DIFF
--- a/python/lsst/obs/lsst/translators/latiss.py
+++ b/python/lsst/obs/lsst/translators/latiss.py
@@ -54,6 +54,9 @@ OBJECT_IS_ENGTEST = Time("2020-01-27T20:00", format="isot", scale="utc")
 # RA and DEC headers are in radians until this date
 RADEC_IS_RADIANS = Time("2020-01-28T22:00", format="isot", scale="utc")
 
+# RASTART/DECSTART/RAEND/DECEND used wrong telescope location before this
+RASTART_IS_BAD = Time("2020-02-01T00:00", format="isot", scale="utc")
+
 # Scaling factor radians to degrees.  Keep it simple.
 RAD2DEG = 180.0 / math.pi
 
@@ -276,6 +279,13 @@ class LsstLatissTranslator(LsstBaseTranslator):
                 header["RADESYS"] = "ICRS"
                 log.debug("%s: Forcing blank RADESYS to '%s'", obsid, header["RADESYS"])
                 modified = True
+
+        if date < RASTART_IS_BAD:
+            # The wrong telescope position was used. Unsetting these will force
+            # the RA/DEC demand headers to be used instead.
+            for h in ("RASTART", "DECSTART", "RAEND", "DECEND"):
+                header[h] = None
+            log.debug("%s: Forcing derived RA/Dec headers to undefined", obsid)
 
         return modified
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -377,6 +377,33 @@ class LsstMetadataTranslatorTestCase(unittest.TestCase, MetadataAssertHelper):
                            temperature=None,
                            visit_id=4702443654717948604,
                            )),
+                     ("latiss-AT_O_20200128_000379.yaml",
+                      dict(telescope="LSSTAuxTel",
+                           instrument="LATISS",
+                           boresight_rotation_coord="sky",
+                           dark_time=5.0*u.s,
+                           detector_exposure_id=2020012800379,
+                           detector_group="RXX",
+                           detector_name="S00",
+                           detector_num=0,
+                           detector_serial="ITL-3800C-068",
+                           exposure_id=2020012800379,
+                           exposure_group="2020-01-29T07:25:52.166",
+                           exposure_time=5.0*u.s,
+                           object="HD107696",
+                           observation_id="AT_O_20200128_000379",
+                           observation_type="science",
+                           physical_filter="KPNO_406_828nm",
+                           pressure=None,
+                           relative_humidity=None,
+                           science_program="unknown",
+                           temperature=None,
+                           visit_id=1602123521660000,
+                           # We have some timing discrepancies in the headers
+                           # that make it hard to match the demand RA/DEC to
+                           # the recorded AZ/EL/TIME.
+                           wcs_params=dict(max_sep=7.),
+                           )),
                      )
         self.assertObservationInfoFromYaml("latiss-future.yaml", dir=self.datadir)
         for filename, expected in test_data:


### PR DESCRIPTION
These headers are always wrong since they were calculated
using an incorrect telescope location. Clearing the headers
forces the RA/DEC to be calculated from the RA/DEC demand
headers.

Note that there is a 7 arcmin discrepancy between the demand
header and the position calulated from AZSTART/ELSTART/DATE-OBS.
7 arcmin is a bit higher than I expected.