### PR TITLE
Fix defects policies.

### DIFF
--- a/policy/comCam/comCamMapper.yaml
+++ b/policy/comCam/comCamMapper.yaml
@@ -1,5 +1,3 @@
-defects: ../description/defects
-
 needCalibRegistry: true
 
 levels:

--- a/policy/latiss/latissMapper.yaml
+++ b/policy/latiss/latissMapper.yaml
@@ -1,5 +1,3 @@
-defects: ../latiss/defects
-
 calibrations:
   bias:
     obsTimeName: dayObs

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -1,5 +1,3 @@
-defects: ../description/defects
-
 needCalibRegistry: true
 
 levels:
@@ -96,14 +94,15 @@ calibrations:
   defects:
     columns:
     - detector
-    - calibDate
+    - dateObs
     level: Ccd
-    persistable: BaseCatalog
+    obsTimeName: dateObs
+    persistable: DefectsList
     python: lsst.meas.algorithms.Defects
     refCols:
     - visit
     reference: raw_visit
-    storage: FitsCatalogStorage
+    storage: FitsStorage
     tables: defects
     template: defects/%(calibDate)s/defects-%(calibDate)s-%(detectorName)s.fits
     validEndName: validEnd


### PR DESCRIPTION
`dateObs` is the correct field to test against the validity range.  The formatter information was also incorrect, and there was a leftover unused `defects` policy setting from when these used to be part of the camera object.