### PR TITLE
Change calibration refCols and reference table.

### DIFF
--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -85,6 +85,13 @@ calibrations:
     python: lsst.meas.algorithms.simple_curve.Curve
     refCols:
     - visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsCatalogStorage
     tables: qe_curve
     template: qe_curve/%(calibDate)s/qe_curve-%(calibDate)s-%(raftName)s-%(detectorName)s.fits
@@ -101,7 +108,13 @@ calibrations:
     python: lsst.meas.algorithms.Defects
     refCols:
     - visit
-    reference: raw_visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsStorage
     tables: defects
     template: defects/%(calibDate)s/defects-%(calibDate)s-%(detectorName)s.fits
@@ -119,7 +132,13 @@ calibrations:
     python: lsst.afw.image.ExposureF
     refCols:
     - visit
-    reference: raw_visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsStorage
     tables: bias
     template: bias/%(calibDate)s/bias-%(raftName)s-%(detectorName)s-det%(detector)03d_%(calibDate)s.fits
@@ -135,7 +154,13 @@ calibrations:
     python: lsst.afw.image.ExposureF
     refCols:
     - visit
-    reference: raw_visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsStorage
     tables: dark
     template: dark/%(calibDate)s/dark-%(raftName)s-%(detectorName)s-det%(detector)03d_%(calibDate)s.fits
@@ -154,7 +179,13 @@ calibrations:
     refCols:
     - visit
     - filter
-    reference: raw_visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsStorage
     tables: flat
     template: flat/%(filter)s/%(calibDate)s/flat_%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d_%(calibDate)s.fits
@@ -173,7 +204,13 @@ calibrations:
     refCols:
     - visit
     - filter
-    reference: raw_visit
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
+    reference: raw
     storage: FitsStorage
     tables: flat
     template: fringe/%(filter)s/%(calibDate)s/fringe_%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d_%(calibDate)s.fits
@@ -215,10 +252,16 @@ calibrations:
     - raftName
     - detectorName
     obsTimeName: dateObs
-    reference: raw_visit
+    reference: raw
     refCols:
     - visit
     - filter
+    - detector
+    - raftName
+    - detectorName
+    - expId
+    - dayObs
+    - seqNum
     filter: true
     validRange: true
     validStartName: validStart


### PR DESCRIPTION
refCols is the list of data id keys that may be specified (their
combination must select a unique dateObs). 'visit' is retained for a
future time when 'snap' can also be included.

The reference table was attempting to use a visit optimization, but ISR
will in general act on exposures, not visits, so we change to the 'raw'
table.