### PR TITLE
DM-15536: adapt to moving visit definition out of ingest

### DIFF
--- a/config/convertRepo.py
+++ b/config/convertRepo.py
@@ -10,3 +10,6 @@ config.ccdKey = "detector"
 config.datasetIgnorePatterns.extend(["_raw", "raw_hdu", "raw_amp"])
 
 config.curatedCalibrations.extend(["defects", "qe_curve"])
+
+import os
+config.defineVisits.load(os.path.join(os.path.dirname(__file__), "defineVisits.py"))

--- a/config/defineVisits.py
+++ b/config/defineVisits.py
@@ -1,0 +1,1 @@
+config.groupExposures.name = "by-group-metadata"


### PR DESCRIPTION
The tests here now just test that trying to define visits from the test data already included in the repo correctly does nothing, because (apparently) none of the exposures here have `observation_type = 'science'`.  When that changes someday in the future (and we include those data IDs in the ingest tests), the tests will fail unless we also set the "visits" attribute to a non-empty dictionary of expected visits, as in the obs_subaru and obs_decam tests.