### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/config/findDefects.py
+++ b/config/findDefects.py
@@ -16,7 +16,6 @@ config.isrForDarks.doFlat = False  # don't flatfield darks
 # none of the calibration products exists to perform these yet
 for config in [config.isrForDarks, config.isrForFlats]:
     config.doCrosstalk = False
-    config.doAddDistortionModel = False
     config.doUseOpticsTransmission = False
     config.doUseFilterTransmission = False
     config.doUseSensorTransmission = False

--- a/config/isr.py
+++ b/config/isr.py
@@ -27,6 +27,5 @@ LSST Cam-specific overrides for IsrTask
 config.doLinearize = False
 config.doDefect = False
 config.doCrosstalk=True
-config.doAddDistortionModel = False
 config.qa.doThumbnailOss = False
 config.qa.doThumbnailFlattened = False

--- a/config/latiss/latiss.py
+++ b/config/latiss/latiss.py
@@ -28,4 +28,3 @@ if hasattr(config, 'ccdKeys'):
 
 config.isr.doLinearize = False
 config.isr.doCrosstalk = False
-config.isr.doAddDistortionModel = False

--- a/config/makeBrighterFatterKernel.py
+++ b/config/makeBrighterFatterKernel.py
@@ -35,7 +35,6 @@ config.isr.doWrite = False
 config.isr.overscanFitType = "AKIMA_SPLINE"
 config.isr.overscanOrder = 30
 
-config.isr.doAddDistortionModel = False
 config.isr.doUseOpticsTransmission = False
 config.isr.doUseFilterTransmission = False
 config.isr.doUseSensorTransmission = False

--- a/config/measurePhotonTransferCurve.py
+++ b/config/measurePhotonTransferCurve.py
@@ -8,7 +8,6 @@ config.ccdKey = 'detector'
 config.isr.doFlat = False
 config.isr.doFringe = False
 config.isr.doCrosstalk = False
-config.isr.doAddDistortionModel = False
 config.isr.doUseOpticsTransmission = False
 config.isr.doUseFilterTransmission = False
 config.isr.doUseSensorTransmission = False

--- a/config/phosim/measureCrosstalk.py
+++ b/config/phosim/measureCrosstalk.py
@@ -23,4 +23,3 @@
 config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doCrosstalk=False
-config.isr.doAddDistortionModel = False

--- a/config/ts3/ts3.py
+++ b/config/ts3/ts3.py
@@ -28,4 +28,3 @@ if hasattr(config, 'ccdKeys'):
 config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doCrosstalk=False
-config.isr.doAddDistortionModel = False

--- a/config/ts8/ts8.py
+++ b/config/ts8/ts8.py
@@ -28,4 +28,3 @@ if hasattr(config, 'ccdKeys'):
 config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doCrosstalk=False
-config.isr.doAddDistortionModel = False

--- a/config/ucd/ucd.py
+++ b/config/ucd/ucd.py
@@ -6,4 +6,3 @@ if hasattr(config, 'ccdKeys'):
 config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doCrosstalk=True
-config.isr.doAddDistortionModel = False


### PR DESCRIPTION
This PR removes all references to the `IsrConfig.doAddDistortionModel` field, which is no longer  used by `IsrTask`.