### PR TITLE
DM-24495: Switch to using __file__ to reference other configs.

### DIFF
--- a/config/assembleCoadd.py
+++ b/config/assembleCoadd.py
@@ -21,10 +21,9 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
 # Load configs shared between assembleCoadd and makeCoaddTempExp
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "coaddBase.py"))
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 
 config.doSigmaClip = False
 config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels)

--- a/config/bias.py
+++ b/config/bias.py
@@ -21,7 +21,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
-config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.load(os.path.join(os.path.dirname(__file__), "lsstCamCommon.py"))
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))

--- a/config/coaddAnalysis.py
+++ b/config/coaddAnalysis.py
@@ -3,12 +3,11 @@ LSST Cam-specific overrides for CoaddAnalysisTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
 # Reference catalog
 config.refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-config.refObjLoader.load(os.path.join(getPackageDir("obs_lsst"), "config", "filterMap.py"))
+config.refObjLoader.load(os.path.join(os.path.dirname(__file__), "filterMap.py"))
 config.refObjLoader.ref_dataset_name="cal_ref_cat"
 
 config.doWriteParquetTables=False

--- a/config/coaddDriver.py
+++ b/config/coaddDriver.py
@@ -24,7 +24,6 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 
 from lsst.pipe.tasks.assembleCoadd import CompareWarpAssembleCoaddTask
 config.assembleCoadd.retarget(CompareWarpAssembleCoaddTask)
@@ -33,7 +32,7 @@ for sub, filename in (("makeCoaddTempExp", "makeCoaddTempExp"),
 #                      ("backgroundReference", "backgroundReference"),
                       ("assembleCoadd", "compareWarpAssembleCoadd"),
                       ("processCoadd", "processCoadd")):
-    path = os.path.join(getPackageDir("obs_lsst"), "config", filename + ".py")
+    path = os.path.join(os.path.dirname(__file__), filename + ".py")
     if os.path.exists(path):
         getattr(config, sub).load(path)
 

--- a/config/compareWarpAssembleCoadd.py
+++ b/config/compareWarpAssembleCoadd.py
@@ -21,10 +21,9 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
 # Load configs from base assembleCoadd
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "assembleCoadd.py"))
+config.load(os.path.join(os.path.dirname(__file__), "assembleCoadd.py"))
 
 # 200 rows (since patch width is typically < 10k pixels
 config.assembleStaticSkyModel.subregionSize = (10000, 200)

--- a/config/dark.py
+++ b/config/dark.py
@@ -21,9 +21,8 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
-config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.load(os.path.join(os.path.dirname(__file__), "lsstCamCommon.py"))
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
 
 #config.repair.cosmicray.nCrPixelMax = 100000

--- a/config/findDefects.py
+++ b/config/findDefects.py
@@ -1,9 +1,8 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
-config.isrForFlats.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
-config.isrForDarks.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.load(os.path.join(os.path.dirname(__file__), "lsstCamCommon.py"))
+config.isrForFlats.load(os.path.join(os.path.dirname(__file__), "isr.py"))
+config.isrForDarks.load(os.path.join(os.path.dirname(__file__), "isr.py"))
 
 config.ccdKey = 'detector'
 

--- a/config/flat.py
+++ b/config/flat.py
@@ -21,7 +21,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
-config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.load(os.path.join(os.path.dirname(__file__), "lsstCamCommon.py"))
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))

--- a/config/forcedPhotCcd.py
+++ b/config/forcedPhotCcd.py
@@ -22,10 +22,9 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "apertures.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "kron.py"))
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "cmodel.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "apertures.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "kron.py"))
+config.load(os.path.join(os.path.dirname(__file__), "cmodel.py"))
 
 config.measurement.slots.gaussianFlux = None

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -22,13 +22,12 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.meas.base import CircularApertureFluxAlgorithm
 
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "apertures.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "kron.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "convolvedFluxes.py"))
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "cmodel.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "apertures.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "kron.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "convolvedFluxes.py"))
+config.load(os.path.join(os.path.dirname(__file__), "cmodel.py"))
 
 config.measurement.slots.gaussianFlux = None
 

--- a/config/imsim/singleFrameDriver.py
+++ b/config/imsim/singleFrameDriver.py
@@ -23,7 +23,4 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
-
-config.processCcd.load(os.path.join(getPackageDir("obs_lsst"), "config",
-                                    "imsim", "processCcd.py"))
+config.processCcd.load(os.path.join(os.path.dirname(__file__), "processCcd.py"))

--- a/config/jointcal.py
+++ b/config/jointcal.py
@@ -21,7 +21,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
 if hasattr(config.astrometryRefObjLoader, "ref_dataset_name"):
     config.astrometryRefObjLoader.ref_dataset_name = 'cal_ref_cat'
@@ -30,6 +29,6 @@ if hasattr(config.photometryRefObjLoader, "ref_dataset_name"):
 # existing synthetic refcat does not have coordinate errors
 config.astrometryReferenceErr = 1
 
-filterMapFile = os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py')
+filterMapFile = os.path.join(os.path.dirname(__file__), "filterMap.py")
 config.astrometryRefObjLoader.load(filterMapFile)
 config.photometryRefObjLoader.load(filterMapFile)

--- a/config/latiss/bias.py
+++ b/config/latiss/bias.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))

--- a/config/latiss/dark.py
+++ b/config/latiss/dark.py
@@ -21,8 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))
 
 config.repair.cosmicray.nCrPixelMax = 100000

--- a/config/latiss/flat.py
+++ b/config/latiss/flat.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))

--- a/config/latiss/fringe.py
+++ b/config/latiss/fringe.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))

--- a/config/latiss/processStar.py
+++ b/config/latiss/processStar.py
@@ -1,7 +1,6 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))
 
 # Configuration for processStarTask
 

--- a/config/latiss/runIsr.py
+++ b/config/latiss/runIsr.py
@@ -1,4 +1,3 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "latiss", "latiss.py"))
+config.load(os.path.join(os.path.dirname(__file__), "latiss.py"))

--- a/config/makeCoaddTempExp.py
+++ b/config/makeCoaddTempExp.py
@@ -21,10 +21,9 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
 # Load configs shared between assembleCoadd and makeCoaddTempExp
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "coaddBase.py"))
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 
 config.makePsfMatched = True
 config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]

--- a/config/measureCoaddSources.py
+++ b/config/measureCoaddSources.py
@@ -23,16 +23,15 @@
 """LSST-specific overrides for MeasureMergedCoaddSourcesTask"""
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "apertures.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "kron.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "convolvedFluxes.py"))
-config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "hsm.py"))
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "cmodel.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "apertures.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "kron.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "convolvedFluxes.py"))
+config.measurement.load(os.path.join(os.path.dirname(__file__), "hsm.py"))
+config.load(os.path.join(os.path.dirname(__file__), "cmodel.py"))
 
 config.match.refObjLoader.ref_dataset_name = "cal_ref_cat"
-config.match.refObjLoader.load(os.path.join(getPackageDir("obs_lsst"), "config", "filterMap.py"))
+config.match.refObjLoader.load(os.path.join(os.path.dirname(__file__), "filterMap.py"))
 config.connections.refCat = "cal_ref_cat"
 
 config.doWriteMatchesDenormalized = True

--- a/config/measurePhotonTransferCurve.py
+++ b/config/measurePhotonTransferCurve.py
@@ -1,8 +1,7 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "lsstCamCommon.py"))
-config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
+config.load(os.path.join(os.path.dirname(__file__), "lsstCamCommon.py"))
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
 
 config.ccdKey = 'detector'
 

--- a/config/multiBandDriver.py
+++ b/config/multiBandDriver.py
@@ -24,10 +24,9 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 
 for sub in ("mergeCoaddDetections", "measureCoaddSources", "mergeCoaddMeasurements", "forcedPhotCoadd"):
-    path = os.path.join(getPackageDir("obs_lsst"), "config", sub + ".py")
+    path = os.path.join(os.path.dirname(__file__), sub + ".py")
     if os.path.exists(path):
         getattr(config, sub).load(path)
 

--- a/config/phosim/singleFrameDriver.py
+++ b/config/phosim/singleFrameDriver.py
@@ -23,7 +23,4 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
-
-config.processCcd.load(os.path.join(getPackageDir("obs_lsst"), "config",
-                                    "phosim", "processCcd.py"))
+config.processCcd.load(os.path.join(os.path.dirname(__file__), "processCcd.py"))

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -25,10 +25,9 @@ LSST Cam-specific overrides for ProcessCcdTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.meas.algorithms import ColorLimit
 
-obsConfigDir = os.path.join(getPackageDir("obs_lsst"), "config")
+obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 config.isr.load(os.path.join(obsConfigDir, "isr.py"))
 
@@ -59,7 +58,7 @@ config.charImage.measurePsf.psfDeterminer.name = "psfex"
 for refObjLoader in (config.charImage.refObjLoader,
                      config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader):
-    refObjLoader.load(os.path.join(getPackageDir('obs_lsst'), 'config', 'filterMap.py'))
+    refObjLoader.load(os.path.join(obsConfigDir, 'filterMap.py'))
     refObjLoader.ref_dataset_name='cal_ref_cat'
 
 config.calibrate.connections.astromRefCat = "cal_ref_cat"

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -25,8 +25,7 @@ LSST Cam-specific overrides for RunIsrTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
 
-obsConfigDir = os.path.join(getPackageDir("obs_lsst"), "config")
+obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/safeClipAssembleCoadd.py
+++ b/config/safeClipAssembleCoadd.py
@@ -21,7 +21,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
 # Load configs from base assembleCoadd
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "assembleCoadd.py"))
+config.load(os.path.join(os.path.dirname(__file__), "assembleCoadd.py"))

--- a/config/singleFrameDriver.py
+++ b/config/singleFrameDriver.py
@@ -22,7 +22,6 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 
-config.processCcd.load(os.path.join(getPackageDir("obs_lsst"), "config", "processCcd.py"))
+config.processCcd.load(os.path.join(os.path.dirname(__file__), "processCcd.py"))
 config.ccdKey = 'detector'

--- a/config/sky.py
+++ b/config/sky.py
@@ -22,11 +22,6 @@
 
 import os.path
 
-# The following will have to be uncommented and adapted when the
-# X-talk correction will be active
-#from lsst.obs.lsst.isr import SubaruIsrTask
-#config.isr.retarget(SubaruIsrTask)
-#config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
 configDir = os.path.dirname(__file__)
 
 config.load(os.path.join(configDir, "lsstCamCommon.py"))

--- a/config/sky.py
+++ b/config/sky.py
@@ -22,13 +22,12 @@
 
 import os.path
 
-from lsst.utils import getPackageDir
 # The following will have to be uncommented and adapted when the
 # X-talk correction will be active
 #from lsst.obs.lsst.isr import SubaruIsrTask
 #config.isr.retarget(SubaruIsrTask)
 #config.isr.load(os.path.join(getPackageDir("obs_lsst"), "config", "isr.py"))
-configDir = os.path.join(getPackageDir("obs_lsst"), "config")
+configDir = os.path.dirname(__file__)
 
 config.load(os.path.join(configDir, "lsstCamCommon.py"))
 config.isr.load(os.path.join(configDir, "isr.py"))

--- a/config/skyCorr.py
+++ b/config/skyCorr.py
@@ -22,7 +22,5 @@
 
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.bgModel.load(os.path.join(getPackageDir('obs_lsst'), 'config',
-                                 'focalPlaneBackground.py'))
+config.bgModel.load(os.path.join(os.path.dirname(__file__), 'focalPlaneBackground.py'))

--- a/config/ts3/bias.py
+++ b/config/ts3/bias.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts3", "ts3.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts3.py"))

--- a/config/ts3/dark.py
+++ b/config/ts3/dark.py
@@ -21,8 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts3", "ts3.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts3.py"))
 
 config.repair.cosmicray.nCrPixelMax = 1000000

--- a/config/ts3/flat.py
+++ b/config/ts3/flat.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts3", "ts3.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts3.py"))

--- a/config/ts3/runIsr.py
+++ b/config/ts3/runIsr.py
@@ -1,4 +1,3 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts3", "ts3.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts3.py"))

--- a/config/ts8/bias.py
+++ b/config/ts8/bias.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts8", "ts8.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts8.py"))

--- a/config/ts8/dark.py
+++ b/config/ts8/dark.py
@@ -21,8 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts8", "ts8.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts8.py"))
 
 config.repair.cosmicray.nCrPixelMax = 1000000

--- a/config/ts8/flat.py
+++ b/config/ts8/flat.py
@@ -21,6 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts8", "ts8.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts8.py"))

--- a/config/ts8/runIsr.py
+++ b/config/ts8/runIsr.py
@@ -1,4 +1,3 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ts8", "ts8.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ts8.py"))

--- a/config/ucd/bias.py
+++ b/config/ucd/bias.py
@@ -1,4 +1,3 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ucd", "ucd.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ucd.py"))

--- a/config/ucd/dark.py
+++ b/config/ucd/dark.py
@@ -1,6 +1,5 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ucd", "ucd.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ucd.py"))
 
 config.repair.cosmicray.nCrPixelMax = 1000000

--- a/config/ucd/flat.py
+++ b/config/ucd/flat.py
@@ -1,4 +1,3 @@
 import os.path
-from lsst.utils import getPackageDir
 
-config.load(os.path.join(getPackageDir("obs_lsst"), "config", "ucd", "ucd.py"))
+config.load(os.path.join(os.path.dirname(__file__), "ucd.py"))

--- a/config/visitAnalysis.py
+++ b/config/visitAnalysis.py
@@ -3,12 +3,11 @@ LSST Cam-specific overrides for VisitAnalysisTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
 # Reference catalog
 config.refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-config.refObjLoader.load(os.path.join(getPackageDir("obs_lsst"), "config", "filterMap.py"))
+config.refObjLoader.load(os.path.join(os.path.dirname(__file__), "filterMap.py"))
 config.refObjLoader.ref_dataset_name="cal_ref_cat"
 
 config.doWriteParquetTables=False


### PR DESCRIPTION
See https://community.lsst.org/t/pex-config-configs-now-know-where-they-are/4023.