### PR TITLE
DM-24804: create a 'convert' butler command

### DIFF
--- a/tests/test_convert2to3.py
+++ b/tests/test_convert2to3.py
@@ -55,46 +55,38 @@ class ConvertGen2To3TestCase(convertTests.ConvertGen2To3TestCase):
 class LatissGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
     instrumentName = "LATISS"
     instrumentDir = "latiss"
-    instrumentClass = "lsst.obs.lsst.Latiss"
+    instrumentClassName = "lsst.obs.lsst.Latiss"
     biases = [{"detector": 0, "calibration_label": "gen2/bias_2018-09-21_000",
                "instrument": instrumentName}]
 
 
 class TS8Gen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
-
     instrumentName = "LSST-TS8"
     instrumentDir = "ts8"
-    instrumentClass = "lsst.obs.lsst.LsstTS8"
+    instrumentClassName = "lsst.obs.lsst.LsstTS8"
     biases = [{"detector": 67, "calibration_label": "gen2/bias_2018-07-24_067",
                "instrument": instrumentName}]
 
 
 class TS3Gen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
-
-    instrumentName = "LSST-TS3"
     instrumentDir = "ts3"
-    instrumentClass = "lsst.obs.lsst.LsstTS3"
+    instrumentClassName = "lsst.obs.lsst.LsstTS3"
 
 
 class UCDCamGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
-
-    instrumentName = "LSST-UCDCam"
     instrumentDir = "ucd"
-    instrumentClass = "lsst.obs.lsst.LsstUCDCam"
+    instrumentClassName = "lsst.obs.lsst.LsstUCDCam"
 
 
 class PhoSimGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
-
-    instrumentName = "LSST-PhoSim"
     instrumentDir = "phosim"
-    instrumentClass = "lsst.obs.lsst.LsstPhoSim"
+    instrumentClassName = "lsst.obs.lsst.LsstPhoSim"
 
 
 class ImSimGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
-
     instrumentName = "LSST-ImSim"
     instrumentDir = "imsim"
-    instrumentClass = "lsst.obs.lsst.LsstImSim"
+    instrumentClassName = "lsst.obs.lsst.LsstImSim"
     biases = [{"detector": 42, "calibration_label": "gen2/bias_2022-01-01_042",
                "instrument": instrumentName}]
     darks = [{"detector": 42, "calibration_label": "gen2/dark_2022-01-01_042",


### PR DESCRIPTION
Where instrument name is not needed for static arguments, dont
specify it; it can be determined from the instrumentClassName.

The var instrumentClass was changed in the base class to
instrumentClassName.