### PR TITLE
DM-25153: Move instrument.py to _instrument.py

### DIFF
--- a/python/lsst/obs/lsst/__init__.py
+++ b/python/lsst/obs/lsst/__init__.py
@@ -23,4 +23,4 @@
 from .version import *
 from .lsstCamMapper import *
 from .filters import *
-from .instrument import *
+from ._instrument import *

--- a/python/lsst/obs/lsst/_instrument.py
+++ b/python/lsst/obs/lsst/_instrument.py
@@ -27,7 +27,7 @@ import os.path
 import lsst.obs.base.yamlCamera as yamlCamera
 from lsst.daf.butler.core.utils import getFullTypeName
 from lsst.utils import getPackageDir
-from lsst.obs.base.instrument import Instrument
+from lsst.obs.base import Instrument
 from lsst.obs.base.gen2to3 import TranslatorFactory
 from .filters import LSSTCAM_FILTER_DEFINITIONS, LATISS_FILTER_DEFINITIONS
 

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -29,7 +29,7 @@ from astro_metadata_translator import fix_header, merge_headers
 import lsst.afw.fits
 from lsst.obs.base.fitsRawFormatterBase import FitsRawFormatterBase
 
-from .instrument import LsstCam, Latiss, \
+from ._instrument import LsstCam, Latiss, \
     LsstImSim, LsstPhoSim, LsstTS8, \
     LsstTS3, LsstUCDCam, LsstComCam
 from .translators import LatissTranslator, LsstCamTranslator, \


### PR DESCRIPTION
This allows us to make clear that the internal location
of the LSST gen3 instrument classes is not relevant
to the user of the package.