### PR TITLE
DM-25171: Change how headers are read from raw data in gen2

### DIFF
--- a/python/lsst/obs/lsst/_fitsHeader.py
+++ b/python/lsst/obs/lsst/_fitsHeader.py
@@ -1,0 +1,71 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+__all__ = ("readRawFitsHeader",)
+
+import re
+from astro_metadata_translator import fix_header, merge_headers
+import lsst.afw.fits
+
+
+def readRawFitsHeader(fileName, translator_class=None):
+    """Read a FITS header from a raw file and fix it up as required.
+
+    Parameters
+    ----------
+    fileName : `str`
+        Name of the FITS file. Can include a HDU specifier (although 0
+        is ignored).
+    translator_class : `~astro_metadata_translator.MetadataTranslator`,
+                       optional
+        Any translator class to use for fixing up the header.
+
+    Returns
+    -------
+    md : `PropertyList`
+        Metadata from file. We also merge the contents with the
+        next HDU if an ``INHERIT`` key is not specified. If an explicit
+        HDU is encoded with the file name and it is greater than 0 then
+        no merging will occur.
+    """
+    mat = re.search(r"\[(\d+)\]$", fileName)
+    hdu = None
+    if mat:
+        # Treat 0 as a special case
+        # For some instruments the primary header is empty
+        requested = int(mat.group(1))
+        if requested > 0:
+            hdu = requested
+
+    if hdu is not None:
+        md = lsst.afw.fits.readMetadata(fileName, hdu=hdu)
+    else:
+        # For raw some of these files need the second header to be
+        # read as well. Not all instruments want the double read
+        # but for now it's easiest to always merge.
+        phdu = lsst.afw.fits.readMetadata(fileName, 0)
+        md = lsst.afw.fits.readMetadata(fileName)
+        md = merge_headers([phdu, md], mode="overwrite")
+
+    fix_header(md, translator_class=translator_class)
+    return md

--- a/python/lsst/obs/lsst/ingest.py
+++ b/python/lsst/obs/lsst/ingest.py
@@ -27,6 +27,7 @@ import lsst.log as lsstLog
 from .translators.lsst import ROLLOVERTIME
 from .translators import LsstCamTranslator
 from .lsstCamMapper import LsstCamMapper
+from ._fitsHeader import readRawFitsHeader
 
 EXTENSIONS = ["fits", "gz", "fz"]  # Filename extensions to strip off
 
@@ -47,6 +48,29 @@ class LsstCamParseTask(ParseTask):
         super().__init__(config, *args, **kwargs)
 
         self.observationInfo = None
+
+    def getInfo(self, filename):
+        """Get information about the image from the filename and its contents
+
+        Here, we open the image and parse the header.
+
+        Parameters
+        ----------
+        filename : `str`
+            Name of file to inspect
+
+        Returns
+        -------
+        info : `dict`
+            File properties
+        linfo : `list` of `dict`
+            List of file properties. Always contains the same as ``info``
+            because no extensions are read.
+        """
+        md = readRawFitsHeader(filename, translator_class=self._translatorClass)
+        phuInfo = self.getInfoFromMetadata(md)
+        # No extensions to worry about
+        return phuInfo, [phuInfo]
 
     def getInfoFromMetadata(self, md, info=None):
         """Attempt to pull the desired information out of the header.

--- a/python/lsst/obs/lsst/utils.py
+++ b/python/lsst/obs/lsst/utils.py
@@ -25,11 +25,11 @@
 Miscellaneous utilities related to lsst cameras
 """
 
-__all__ = ("readRawFile",)
+__all__ = ("readRawFile", "readRawFitsHeader")
 
-import lsst.afw.fits
 from .lsstCamMapper import assemble_raw
 from .assembly import readRawAmps
+from ._fitsHeader import readRawFitsHeader
 
 
 def readRawFile(fileName, detector, dataId=None):
@@ -59,7 +59,7 @@ def readRawFile(fileName, detector, dataId=None):
     amps = readRawAmps(fileName, detector=detector)
 
     component_info = {}
-    component_info["raw_hdu"] = Info(lsst.afw.fits.readMetadata(fileName, hdu=0))
+    component_info["raw_hdu"] = Info(readRawFitsHeader(fileName))
     component_info["raw_amp"] = Info(amps)
 
     exp = assemble_raw(dataId, component_info, None)

--- a/tests/data/LSST-PhoSim-204595.yaml
+++ b/tests/data/LSST-PhoSim-204595.yaml
@@ -1,0 +1,2 @@
+NEWHDR: corrected
+TEMPERA: 10.0

--- a/tests/test_lsstCam.py
+++ b/tests/test_lsstCam.py
@@ -135,9 +135,14 @@ class TestLsstCam(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
 
     def testObsid(self):
         """Check that we can retrieve data using the obsid."""
-        raw = self.butler.get('raw', {'obsid': "MC_C_20190319_000001", 'detectorName': 'S02',
-                                      'raftName': 'R10'})
+        dataId = {'obsid': "MC_C_20190319_000001", 'detectorName': 'S02',
+                  'raftName': 'R10'}
+        raw = self.butler.get('raw', dataId)
         self.assertIsNotNone(raw)
+
+        # And that we can get just the header
+        md = self.butler.get('raw_md', dataId)
+        self.assertEqual(md["TELESCOP"], "LSST")
 
     def testCcdExposureId(self):
         with self.assertRaises(KeyError):


### PR DESCRIPTION
* Add helper function that reads the primary header and merges it with the first amp header. PhoSim requires this.
* Add specialist bypass_raw_hdu so that assembled raws can use the helper function.
* Add specialist bypass_raw_md method that uses the same helper function.  This allows header corrections  to be applied.
* Add new tests to ensure that visitInfo, Exposure, and metadata have header corrections applied.