### PR TITLE
DM-25461: Remove left over export from __all__

### DIFF
--- a/python/lsst/obs/lsst/utils.py
+++ b/python/lsst/obs/lsst/utils.py
@@ -25,7 +25,7 @@
 Miscellaneous utilities related to lsst cameras
 """
 
-__all__ = ("readRawFile", "readRawFitsHeader")
+__all__ = ("readRawFile",)
 
 from .lsstCamMapper import assemble_raw
 from .assembly import readRawAmps


### PR DESCRIPTION
In a previous development version the function was in that
file but it was moved before merging and the linter did not
spot it but the sphinx build did.