### PR TITLE
DM-25923: Remove local caching of yaml camera geom in gen2+gen3

### DIFF
--- a/python/lsst/obs/lsst/_instrument.py
+++ b/python/lsst/obs/lsst/_instrument.py
@@ -78,7 +78,6 @@ class LsstCam(Instrument):
     instrument = "LSSTCam"
     policyName = "lsstCam"
     _camera = None
-    _cameraCachedClass = None
     translatorClass = LsstCamTranslator
     obsDataPackage = "obs_lsst_data"
 
@@ -94,13 +93,11 @@ class LsstCam(Instrument):
 
     @classmethod
     def getCamera(cls):
-        # Constructing a YAML camera takes a long time so cache the result
-        # We have to be careful to ensure we cache at the subclass level
-        # since LsstCam base class will look like a cache to the subclasses
-        if cls._camera is None or cls._cameraCachedClass != cls:
+        # Constructing a YAML camera takes a long time so defer reading
+        # until we need to.  We rely on caching in yaml camera itself.
+        if cls._camera is None:
             cameraYamlFile = os.path.join(PACKAGE_DIR, "policy", f"{cls.policyName}.yaml")
             cls._camera = yamlCamera.makeCamera(cameraYamlFile)
-            cls._cameraCachedClass = cls
         return cls._camera
 
     def getRawFormatter(self, dataId):

--- a/python/lsst/obs/lsst/lsstCamMapper.py
+++ b/python/lsst/obs/lsst/lsstCamMapper.py
@@ -23,7 +23,6 @@
 """The LsstCam Mapper."""  # necessary to suppress D100 flake8 warning.
 
 import os
-from functools import lru_cache
 import lsst.log
 import lsst.geom
 import lsst.utils as utils
@@ -167,13 +166,6 @@ class LsstCamBaseMapper(CameraMapper):
         -------
         camera : `lsst.afw.cameraGeom.Camera`
             Camera geometry.
-        """
-        return cls._makeYamlCamera(cameraYamlFile=cameraYamlFile)
-
-    @classmethod
-    @lru_cache(maxsize=10)
-    def _makeYamlCamera(cls, cameraYamlFile=None):
-        """Helper function for _makeCamera that can be cached.
         """
         if not cameraYamlFile:
             cameraYamlFile = os.path.join(utils.getPackageDir(cls.packageName), "policy",


### PR DESCRIPTION
The cache is moving to yamlCamera.makeCamera.

Tests run 35 seconds faster with yamlCamera caching over
caching separately in gen2 and gen3.

For reference before the cache was added to gen2 mapper
in DM-25890, the tests took 9.5 minutes (no parallelism, on my Mac).
Now they take 5.25 minutes.

Relies on lsst/obs_base#275