### PR TITLE
DM-26070: Add visit definition to ap_verify

### DIFF
--- a/config/datasetIngest-gen3.py
+++ b/config/datasetIngest-gen3.py
@@ -1,0 +1,7 @@
+# Config override for lsst.ap.verify.Gen3DatasetIngestTask
+
+import os
+
+configDir = os.path.dirname(__file__)
+
+config.visitDefiner.load(os.path.join(configDir, 'defineVisits.py'))


### PR DESCRIPTION
This PR adds a default ImSim configuration for `ap_verify`'s `Gen3DatasetIngestTask`.