### PR TITLE
DM-23302: Add ci_cpp package to allow calibration product generation to be tested

### DIFF
--- a/pipelines/latiss/cpDark.yaml
+++ b/pipelines/latiss/cpDark.yaml
@@ -13,7 +13,7 @@ tasks:
       doVariance: True
       doLinearize: False
       doCrosstalk: False
-      doDefect: False
+      doDefect: True
       doNanMasking: True
       doInterpolate: True
       doBrighterFatter: False

--- a/pipelines/latiss/cpFlat.yaml
+++ b/pipelines/latiss/cpFlat.yaml
@@ -26,12 +26,13 @@ tasks:
     config:
       connections.inputExp: 'cpFlatProc'
       connections.outputStats: 'flatStats'
+      doVignette: False
   cpFlatNorm:
     class: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
     config:
       connections.inputMDs: 'flatStats'
       connections.outputScales: 'cpFlatNormScales'
-  cpCombine:
+  cpFlatCombine:
     class: lsst.cp.pipe.cpCombine.CalibCombineTask
     config:
       connections.inputExps: 'cpFlatProc'

--- a/pipelines/latiss/cpFlat.yaml
+++ b/pipelines/latiss/cpFlat.yaml
@@ -13,7 +13,7 @@ tasks:
       doVariance: True
       doLinearize: False
       doCrosstalk: False
-      doDefect: False
+      doDefect: True
       doNanMasking: True
       doInterpolate: True
       doDark: True


### PR DESCRIPTION
Modify LATISS calibration production pipelines to fix errors.