### PR TITLE
DM-26978: Rename imSim and PhoSim instrument/translator classes

### DIFF
--- a/python/lsst/obs/lsst/_instrument.py
+++ b/python/lsst/obs/lsst/_instrument.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ("LsstCam", "LsstImSim", "LsstPhoSim", "LsstTS8",
+__all__ = ("LsstCam", "LsstCamImSim", "LsstCamPhoSim", "LsstTS8",
            "Latiss", "LsstTS3", "LsstUCDCam", "LsstComCam")
 
 import os.path
@@ -30,13 +30,13 @@ from lsst.utils import getPackageDir
 from lsst.obs.base import Instrument
 from lsst.obs.base.gen2to3 import TranslatorFactory
 from .filters import (LSSTCAM_FILTER_DEFINITIONS, LATISS_FILTER_DEFINITIONS,
-                      LSST_IMSIM_FILTER_DEFINITIONS, TS3_FILTER_DEFINITIONS,
+                      LSSTCAM_IMSIM_FILTER_DEFINITIONS, TS3_FILTER_DEFINITIONS,
                       TS8_FILTER_DEFINITIONS, COMCAM_FILTER_DEFINITIONS,
                       )
 
 from .translators import LatissTranslator, LsstCamTranslator, \
     LsstUCDCamTranslator, LsstTS3Translator, LsstComCamTranslator, \
-    LsstPhoSimTranslator, LsstTS8Translator, LsstImSimTranslator
+    LsstCamPhoSimTranslator, LsstTS8Translator, LsstCamImSimTranslator
 
 PACKAGE_DIR = getPackageDir("obs_lsst")
 
@@ -175,33 +175,33 @@ class LsstComCam(LsstCam):
         return LsstComCamRawFormatter
 
 
-class LsstImSim(LsstCam):
+class LsstCamImSim(LsstCam):
     """Gen3 Butler specialization for ImSim simulations.
     """
 
     instrument = "LSSTCam-imSim"
     policyName = "imsim"
-    translatorClass = LsstImSimTranslator
-    filterDefinitions = LSST_IMSIM_FILTER_DEFINITIONS
+    translatorClass = LsstCamImSimTranslator
+    filterDefinitions = LSSTCAM_IMSIM_FILTER_DEFINITIONS
 
     def getRawFormatter(self, dataId):
         # local import to prevent circular dependency
-        from .rawFormatter import LsstImSimRawFormatter
-        return LsstImSimRawFormatter
+        from .rawFormatter import LsstCamImSimRawFormatter
+        return LsstCamImSimRawFormatter
 
 
-class LsstPhoSim(LsstCam):
+class LsstCamPhoSim(LsstCam):
     """Gen3 Butler specialization for Phosim simulations.
     """
 
     instrument = "LSSTCam-PhoSim"
     policyName = "phosim"
-    translatorClass = LsstPhoSimTranslator
+    translatorClass = LsstCamPhoSimTranslator
 
     def getRawFormatter(self, dataId):
         # local import to prevent circular dependency
-        from .rawFormatter import LsstPhoSimRawFormatter
-        return LsstPhoSimRawFormatter
+        from .rawFormatter import LsstCamPhoSimRawFormatter
+        return LsstCamPhoSimRawFormatter
 
 
 class LsstTS8(LsstCam):

--- a/python/lsst/obs/lsst/filters.py
+++ b/python/lsst/obs/lsst/filters.py
@@ -19,7 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ()
+__all__ = (
+    "LSSTCAM_FILTER_DEFINITIONS",
+    "LATISS_FILTER_DEFINITIONS",
+    "LSSTCAM_IMSIM_FILTER_DEFINITIONS",
+    "TS3_FILTER_DEFINITIONS",
+    "TS8_FILTER_DEFINITIONS",
+    "COMCAM_FILTER_DEFINITIONS",
+)
 
 import re
 from lsst.obs.base import FilterDefinition, FilterDefinitionCollection
@@ -246,7 +253,7 @@ for filter in _latiss_filters:
 LATISS_FILTER_DEFINITIONS = FilterDefinitionCollection(*_latiss_filter_and_grating)
 
 
-LSST_IMSIM_FILTER_DEFINITIONS = FilterDefinitionCollection(
+LSSTCAM_IMSIM_FILTER_DEFINITIONS = FilterDefinitionCollection(
     # These were computed using throughputs 1.4 and
     # lsst.sims.photUtils.BandpassSet.
     FilterDefinition(physical_filter="u_sim_1.4",

--- a/python/lsst/obs/lsst/imsim.py
+++ b/python/lsst/obs/lsst/imsim.py
@@ -22,27 +22,27 @@
 #
 from . import LsstCamMapper, LsstCamMakeRawVisitInfo
 from .ingest import LsstCamParseTask
-from .translators import LsstImSimTranslator
-from ._instrument import LsstImSim
-from .filters import LSST_IMSIM_FILTER_DEFINITIONS
+from .translators import LsstCamImSimTranslator
+from ._instrument import LsstCamImSim
+from .filters import LSSTCAM_IMSIM_FILTER_DEFINITIONS
 
 __all__ = ["ImsimMapper", "ImsimParseTask"]
 
 
 class ImsimMakeRawVisitInfo(LsstCamMakeRawVisitInfo):
     """Make a VisitInfo from the FITS header of a raw image."""
-    metadataTranslator = LsstImSimTranslator
+    metadataTranslator = LsstCamImSimTranslator
 
 
 class ImsimMapper(LsstCamMapper):
     """The Mapper for the imsim simulations of the LsstCam."""
-    translatorClass = LsstImSimTranslator
+    translatorClass = LsstCamImSimTranslator
     MakeRawVisitInfoClass = ImsimMakeRawVisitInfo
-    _gen3instrument = LsstImSim
+    _gen3instrument = LsstCamImSim
 
     _cameraName = "imsim"
     yamlFileList = ["imsim/imsimMapper.yaml"] + list(LsstCamMapper.yamlFileList)
-    filterDefinitions = LSST_IMSIM_FILTER_DEFINITIONS
+    filterDefinitions = LSSTCAM_IMSIM_FILTER_DEFINITIONS
 
     def bypass_ccdExposureId_bits(self, datasetType, pythonType, location, dataId):
         """How many bits are required for the maximum exposure ID"""
@@ -54,7 +54,7 @@ class ImsimParseTask(LsstCamParseTask):
     """
 
     _mapperClass = ImsimMapper
-    _translatorClass = LsstImSimTranslator
+    _translatorClass = LsstCamImSimTranslator
 
     def translate_controller(self, md):
         """Always return Simulation as controller for imsim data."""

--- a/python/lsst/obs/lsst/phosim.py
+++ b/python/lsst/obs/lsst/phosim.py
@@ -20,24 +20,24 @@
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
+__all__ = ["PhosimMapper", "PhosimParseTask", "PhosimEimgParseTask"]
+
 from . import LsstCamMapper, LsstCamMakeRawVisitInfo
 from .ingest import LsstCamParseTask
-from .translators import LsstPhoSimTranslator
-from ._instrument import LsstPhoSim
-
-__all__ = ["PhosimMapper", "PhosimParseTask", "PhosimEimgParseTask"]
+from .translators import LsstCamPhoSimTranslator
+from ._instrument import LsstCamPhoSim
 
 
 class PhosimRawVisitInfo(LsstCamMakeRawVisitInfo):
     """Make a VisitInfo from the FITS header of a raw image."""
-    metadataTranslator = LsstPhoSimTranslator
+    metadataTranslator = LsstCamPhoSimTranslator
 
 
 class PhosimMapper(LsstCamMapper):
     """The Mapper for the phosim simulations of the LsstCam."""
-    translatorClass = LsstPhoSimTranslator
+    translatorClass = LsstCamPhoSimTranslator
     MakeRawVisitInfoClass = PhosimRawVisitInfo
-    _gen3instrument = LsstPhoSim
+    _gen3instrument = LsstCamPhoSim
 
     _cameraName = "phosim"
     yamlFileList = ["imsim/imsimMapper.yaml"] + list(LsstCamMapper.yamlFileList)
@@ -52,7 +52,7 @@ class PhosimParseTask(LsstCamParseTask):
     """
 
     _mapperClass = PhosimMapper
-    _translatorClass = LsstPhoSimTranslator
+    _translatorClass = LsstCamPhoSimTranslator
 
     def translate_controller(self, md):
         """Always return Simulation as controller for imsim data."""

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -22,7 +22,16 @@
 """Gen3 Butler Formatters for LSST raw data.
 """
 
-__all__ = ("LsstCamRawFormatter", "LatissRawFormatter")
+__all__ = (
+    "LsstCamRawFormatter",
+    "LatissRawFormatter",
+    "LsstCamImSimRawFormatter",
+    "LsstCamPhoSimRawFormatter",
+    "LsstTS8RawFormatter",
+    "LsstTS3RawFormatter",
+    "LsstComCamRawFormatter",
+    "LsstUCDCamRawFormatter",
+)
 
 from astro_metadata_translator import fix_header, merge_headers
 
@@ -30,11 +39,11 @@ import lsst.afw.fits
 from lsst.obs.base import FitsRawFormatterBase
 
 from ._instrument import LsstCam, Latiss, \
-    LsstImSim, LsstPhoSim, LsstTS8, \
+    LsstCamImSim, LsstCamPhoSim, LsstTS8, \
     LsstTS3, LsstUCDCam, LsstComCam
 from .translators import LatissTranslator, LsstCamTranslator, \
     LsstUCDCamTranslator, LsstTS3Translator, LsstComCamTranslator, \
-    LsstPhoSimTranslator, LsstTS8Translator, LsstImSimTranslator
+    LsstCamPhoSimTranslator, LsstTS8Translator, LsstCamImSimTranslator
 from .assembly import fixAmpsAndAssemble, readRawAmps
 
 
@@ -126,16 +135,16 @@ class LatissRawFormatter(LsstCamRawFormatter):
     wcsFlipX = True
 
 
-class LsstImSimRawFormatter(LsstCamRawFormatter):
-    translatorClass = LsstImSimTranslator
-    _instrument = LsstImSim
-    filterDefinitions = LsstImSim.filterDefinitions
+class LsstCamImSimRawFormatter(LsstCamRawFormatter):
+    translatorClass = LsstCamImSimTranslator
+    _instrument = LsstCamImSim
+    filterDefinitions = LsstCamImSim.filterDefinitions
 
 
-class LsstPhoSimRawFormatter(LsstCamRawFormatter):
-    translatorClass = LsstPhoSimTranslator
-    _instrument = LsstPhoSim
-    filterDefinitions = LsstPhoSim.filterDefinitions
+class LsstCamPhoSimRawFormatter(LsstCamRawFormatter):
+    translatorClass = LsstCamPhoSimTranslator
+    _instrument = LsstCamPhoSim
+    filterDefinitions = LsstCamPhoSim.filterDefinitions
 
 
 class LsstTS8RawFormatter(LsstCamRawFormatter):

--- a/python/lsst/obs/lsst/translators/imsim.py
+++ b/python/lsst/obs/lsst/translators/imsim.py
@@ -8,9 +8,9 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for ImSim headers"""
+"""Metadata translation code for LSSTCam imSim headers"""
 
-__all__ = ("LsstImSimTranslator", )
+__all__ = ("LsstCamImSimTranslator", )
 
 import logging
 import astropy.units as u
@@ -29,8 +29,8 @@ from .lsstsim import LsstSimTranslator
 log = logging.getLogger(__name__)
 
 
-class LsstImSimTranslator(LsstSimTranslator):
-    """Metadata translation class for ImSim headers"""
+class LsstCamImSimTranslator(LsstSimTranslator):
+    """Metadata translation class for LSSTCam imSim headers"""
 
     name = "LSSTCam-imSim"
     """Name of this translation class"""

--- a/python/lsst/obs/lsst/translators/phosim.py
+++ b/python/lsst/obs/lsst/translators/phosim.py
@@ -8,9 +8,9 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for LSST PhoSim FITS headers"""
+"""Metadata translation code for LSSTCam PhoSim FITS headers"""
 
-__all__ = ("LsstPhoSimTranslator", )
+__all__ = ("LsstCamPhoSimTranslator", )
 
 import logging
 
@@ -27,8 +27,8 @@ from .lsstsim import LsstSimTranslator
 log = logging.getLogger(__name__)
 
 
-class LsstPhoSimTranslator(LsstSimTranslator):
-    """Metadata translator for LSST PhoSim data.
+class LsstCamPhoSimTranslator(LsstSimTranslator):
+    """Metadata translator for LSSTCam PhoSim data.
     """
 
     name = "LSSTCam-PhoSim"

--- a/tests/test_butlerCmd.py
+++ b/tests/test_butlerCmd.py
@@ -32,12 +32,12 @@ class TestButlerCmdLsstComCam(ButlerCmdTestBase, lsst.utils.tests.TestCase):
     instrumentClassName = "lsst.obs.lsst.LsstComCam"
 
 
-class TestButlerCmdLsstImSim(ButlerCmdTestBase, lsst.utils.tests.TestCase):
-    instrumentClassName = "lsst.obs.lsst.LsstImSim"
+class TestButlerCmdLsstCamImSim(ButlerCmdTestBase, lsst.utils.tests.TestCase):
+    instrumentClassName = "lsst.obs.lsst.LsstCamImSim"
 
 
-class TestButlerCmdLsstPhoSim(ButlerCmdTestBase, lsst.utils.tests.TestCase):
-    instrumentClassName = "lsst.obs.lsst.LsstPhoSim"
+class TestButlerCmdLsstCamPhoSim(ButlerCmdTestBase, lsst.utils.tests.TestCase):
+    instrumentClassName = "lsst.obs.lsst.LsstCamPhoSim"
 
 
 class TestButlerCmdLsstTS8(ButlerCmdTestBase, lsst.utils.tests.TestCase):

--- a/tests/test_convert2to3.py
+++ b/tests/test_convert2to3.py
@@ -87,7 +87,7 @@ class UCDCamGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
 
 class PhoSimGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
     instrumentDir = "phosim"
-    instrumentClassName = "lsst.obs.lsst.LsstPhoSim"
+    instrumentClassName = "lsst.obs.lsst.LsstCamPhoSim"
 
     def check_defects(self, gen3Butler, detectors):
         # Disable defects tests, because there are no defects.
@@ -97,7 +97,7 @@ class PhoSimGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
 class ImSimGen2To3TestCase(ConvertGen2To3TestCase, lsst.utils.tests.TestCase):
     instrumentName = "LSSTCam-imSim"
     instrumentDir = "imsim"
-    instrumentClassName = "lsst.obs.lsst.LsstImSim"
+    instrumentClassName = "lsst.obs.lsst.LsstCamImSim"
     biases = [{"detector": 42, "instrument": instrumentName}]
     darks = [{"detector": 42, "instrument": instrumentName}]
     flats = [{"detector": 42, "instrument": instrumentName, "physical_filter": "i_sim_1.4"}]

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -28,7 +28,7 @@ from pstats import Stats
 
 import numpy as np
 
-from lsst.obs.lsst import (LsstCam, LsstComCam, LsstImSim, LsstPhoSim,
+from lsst.obs.lsst import (LsstCam, LsstComCam, LsstCamImSim, LsstCamPhoSim,
                            LsstTS8, LsstTS3, LsstUCDCam, Latiss)
 
 from lsst.daf.butler import (Butler, DatasetType, FileDescriptor, Location,
@@ -138,11 +138,11 @@ class TestInstruments(unittest.TestCase):
         self.checkInstrumentWithRegistry(LsstComCam, testFpath)
 
     def testImSim(self):
-        self.checkInstrumentWithRegistry(LsstImSim,
+        self.checkInstrumentWithRegistry(LsstCamImSim,
                                          "imsim/raw/204595/R11/00204595-R11-S20-det042.fits")
 
     def testPhoSim(self):
-        self.checkInstrumentWithRegistry(LsstPhoSim,
+        self.checkInstrumentWithRegistry(LsstCamPhoSim,
                                          "phosim/raw/204595/R11/00204595-R11-S20-det042.fits")
 
     def testTs8(self):


### PR DESCRIPTION
LsstImSim -> LsstCamImSim
LsstPhoSim -> LsstCamPhoSim

since these are simulations specifically of LSSTCam.