### PR TITLE
DM-28583: Pass dummy data ID when constructing Formatter in tests.

### DIFF
--- a/python/lsst/obs/lsst/__init__.py
+++ b/python/lsst/obs/lsst/__init__.py
@@ -24,3 +24,4 @@ from .version import *
 from .lsstCamMapper import *
 from .filters import *
 from ._instrument import *
+from ._fitsHeader import *


### PR DESCRIPTION
This is a bit fragile, as it assumes the Formatter isn't going to care that the data ID doesn't really make sense, and that may change in the future.  See DM-28698 for further discussion.