### PR TITLE
DM-29019: Interpret detector_max as exclusive bound on zero-based detector_nums.

### DIFF
--- a/python/lsst/obs/lsst/translators/lsst.py
+++ b/python/lsst/obs/lsst/translators/lsst.py
@@ -94,7 +94,7 @@ def read_detector_ids(policyFile):
     return mapping
 
 
-def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000):
+def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num):
     """Compute the detector_exposure_id from the exposure id and the
     detector number.
 
@@ -104,8 +104,8 @@ def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000
         The exposure ID.
     detector_num : `int`
         The detector number.
-    max_num : `int`, optional
-        Maximum number of detectors to make space for. Defaults to 1000.
+    max_num : `int`
+        Maximum number of detectors to make space for.
 
     Returns
     -------

--- a/python/lsst/obs/lsst/translators/lsst.py
+++ b/python/lsst/obs/lsst/translators/lsst.py
@@ -94,7 +94,7 @@ def read_detector_ids(policyFile):
     return mapping
 
 
-def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000, mode="concat"):
+def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000):
     """Compute the detector_exposure_id from the exposure id and the
     detector number.
 
@@ -106,12 +106,6 @@ def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000
         The detector number.
     max_num : `int`, optional
         Maximum number of detectors to make space for. Defaults to 1000.
-    mode : `str`, optional
-        Computation mode. Defaults to "concat".
-        - concat : Concatenate the exposure ID and detector number, making
-                   sure that there is space for max_num and zero padding.
-        - multiply : Multiply the exposure ID by the maximum detector
-                     number and add the detector number.
 
     Returns
     -------
@@ -129,13 +123,7 @@ def compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=1000
     if detector_num >= max_num or detector_num < 0:
         raise ValueError(f"Detector number out of range 0 <= {detector_num} < {max_num}")
 
-    if mode == "concat":
-        npad = len(str(max_num - 1))
-        return int(f"{exposure_id}{detector_num:0{npad}d}")
-    elif mode == "multiply":
-        return max_num*exposure_id + detector_num
-    else:
-        raise ValueError(f"Computation mode of '{mode}' is not understood")
+    return max_num*exposure_id + detector_num
 
 
 class LsstBaseTranslator(FitsTranslator):
@@ -215,9 +203,7 @@ class LsstBaseTranslator(FitsTranslator):
         detector_exposure_id : `int`
             The calculated ID.
         """
-        return compute_detector_exposure_id_generic(exposure_id, detector_num,
-                                                    max_num=cls.DETECTOR_MAX,
-                                                    mode="concat")
+        return compute_detector_exposure_id_generic(exposure_id, detector_num, max_num=cls.DETECTOR_MAX)
 
     @classmethod
     def max_detector_exposure_id(cls):

--- a/python/lsst/obs/lsst/translators/lsst_ucdcam.py
+++ b/python/lsst/obs/lsst/translators/lsst_ucdcam.py
@@ -75,9 +75,12 @@ class LsstUCDCamTranslator(LsstBaseTranslator):
     """Map detector serial to raft and detector number.  Eventually the
     detector number will come out of the policy camera definition."""
 
-    DETECTOR_MAX = 3
+    DETECTOR_MAX = 10
     """Maximum number of detectors to use when calculating the
-    detector_exposure_id."""
+    detector_exposure_id.
+
+    This is rounded up to a power of ten to make those IDs human-decodable.
+    """
 
     _ROLLOVER_TIME = TimeDelta(8*60*60, scale="tai", format="sec")
     """Time delta for the definition of a Rubin Test Stand start of day."""

--- a/python/lsst/obs/lsst/translators/ts3.py
+++ b/python/lsst/obs/lsst/translators/ts3.py
@@ -63,10 +63,6 @@ class LsstTS3Translator(LsstBaseTranslator):
     DETECTOR_NAME = _DETECTOR_NAME
     """Fixed name of single sensor."""
 
-    DETECTOR_MAX = 999
-    """Maximum number of detectors to use when calculating the
-    detector_exposure_id."""
-
     cameraPolicyFile = "policy/ts3.yaml"
 
     _ROLLOVER_TIME = TimeDelta(8*60*60, scale="tai", format="sec")

--- a/python/lsst/obs/lsst/translators/ts8.py
+++ b/python/lsst/obs/lsst/translators/ts8.py
@@ -53,10 +53,6 @@ class LsstTS8Translator(LsstBaseTranslator):
         "exposure_time": ("EXPTIME", dict(unit=u.s)),
     }
 
-    DETECTOR_MAX = 250
-    """Maximum number of detectors to use when calculating the
-    detector_exposure_id."""
-
     cameraPolicyFile = "policy/ts8.yaml"
 
     _ROLLOVER_TIME = TimeDelta(8*60*60, scale="tai", format="sec")

--- a/tests/test_ucdcam.py
+++ b/tests/test_ucdcam.py
@@ -129,9 +129,6 @@ class TestUcdCam(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
                                                               "detectorName": "S00"})
         self.assertEqual(exposureId, 11)
 
-        with self.assertRaises(ValueError):
-            self.butler.get('ccdExposureId', dataId={"visit": 1, "detector": 4})
-
         with self.assertRaises(KeyError):
             self.butler.get('ccdExposureId', dataId={"visit": 1})
 


### PR DESCRIPTION
The naming isn't great, but this is the interpretation that daf_butler and other cameras have assumed, and we need obs_lsst to be the same in order for DimensionPacker to behave consistently with astro_metadata_translator until we can unify that log.

This removes the DETECTOR_MAX override for TS3 because it should just inherit the same value from its base class anyway.