### PR TITLE
DM-24704: Make brighter-fatter correction a subclass of lsst.ip.isr.IsrCalib

### DIFF
--- a/pipelines/latiss/cpBfkSolve.yaml
+++ b/pipelines/latiss/cpBfkSolve.yaml
@@ -1,0 +1,9 @@
+description: cp_pipe PTC calibration construction.
+instrument: lsst.obs.lsst.Latiss
+tasks:
+  bfkSolve:
+    class: lsst.cp.pipe.BrighterFatterKernelSolveTask
+    config:
+      connections.inputPtc: ptc
+      connections.outputBFK: bfk
+

--- a/policy/latiss/latissMapper.yaml
+++ b/policy/latiss/latissMapper.yaml
@@ -29,7 +29,7 @@ datasets:
   runIsr_metadata:
     template: runIsr_metadata/%(expId)013d-%(filter)s/runIsrMetadata_%(expId)013d-%(filter)s-%(detectorName)s-det%(detector)03d.yaml
   brighterFatterKernel:
-    template: calibrations/bfKernel-%(detectorName)s-det%(detector)03d.pkl
+    template: calibrations/bfKernel-%(detectorName)s-det%(detector)03d.fits
   linearizeLut:
     template: calibrations/linearizers/linearize-lut-det%(detector)03d_%(calibDate)s.fits
   linearizeSquared:

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -499,9 +499,7 @@ datasets:
   runIsr_metadata:
     template: runIsr_metadata/%(expId)013d-%(filter)s/%(raftName)s/runIsrMetadata_%(expId)013d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
   brighterFatterKernel:
-    template: calibrations/bfKernel-%(raftName)s-%(detectorName)s-det%(detector)03d.pkl
-  brighterFatterGain:
-    template: calibrations/bfGain-%(detector)03d.pkl
+    template: calibrations/bfKernel-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   plotBrighterFatterPtc:
     template: plots/bfPtc-ccd-%(detector)03d-amp-%(amp)s.png
   measurePhotonTransferCurve_metadata:


### PR DESCRIPTION
Add LATISS pipeline, and fix mapper expectations.