### PR TITLE
DM-29336: Templates are identical for icExp and icExpBackground in obs_lsst

### DIFF
--- a/policy/imsim/imsimMapper.yaml
+++ b/policy/imsim/imsimMapper.yaml
@@ -60,7 +60,7 @@ datasets:
   forcedPhotCcd_metadata:
     template: forcedPhotCcd_metadata/%(visit)08d-%(filter)s/%(raftName)s/forcedPhotCcd_metadata_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.yaml
   icExpBackground:
-    template: icExp/%(visit)08d-%(filter)s/%(raftName)s/icExp_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: icExp/%(visit)08d-%(filter)s/%(raftName)s/bkgd_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   icSrc:
     template: icSrc/%(visit)08d-%(filter)s/%(raftName)s/icSrc_%(visit)08d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   processCcd_metadata:

--- a/policy/latiss/latissMapper.yaml
+++ b/policy/latiss/latissMapper.yaml
@@ -46,6 +46,8 @@ datasets:
     template: calexp/%(expId)013d-%(filter)s/bkgd_%(expId)013d-%(filter)s-det%(detector)03d.fits
   processCcd_metadata:
     template: processCcd_metadata/%(expId)013d-%(filter)s/processCcdMetadata_%(expId)013d-%(filter)s-det%(detector)03d.yaml
+  icExpBackground:
+    template: icExp/%(expId)013d-%(filter)s/bkgd_%(expId)013d-%(filter)s-det%(detector)03d.fits
 
 exposures:
   _raw:

--- a/policy/lsstCamMapper.yaml
+++ b/policy/lsstCamMapper.yaml
@@ -425,11 +425,7 @@ datasets:
     tables: raw
     template: ignored
   icExpBackground:
-    persistable: PurePythonClass
-    python: lsst.afw.math.BackgroundList
-    storage: FitsCatalogStorage
-    tables: raw
-    template: icExp/%(expId)013d-%(filter)s/%(raftName)s/icExp_%(expId)013d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
+    template: icExp/%(expId)013d-%(filter)s/%(raftName)s/bkgd_%(expId)013d-%(filter)s-%(raftName)s-%(detectorName)s-det%(detector)03d.fits
   icSrc:
     persistable: SourceCatalog
     python: lsst.afw.table.SourceCatalog


### PR DESCRIPTION
The policy templates were identical for the icExp and icExpBackground datasets
thus a "put" of one would overwrite the other.  Fixed here by updating the
template of the latter.