### PR TITLE
DM-22277: Exclude objectTable subset from DRP pipeline until tested

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -3,3 +3,4 @@ imports:
   - location: $PIPE_TASKS_DIR/pipelines/DRP.yaml
     exclude:
       - sourceTable
+      - objectTable


### PR DESCRIPTION
DM-22277 converts to gen3 the tasks the convert the `deepCoadd_{meas|ref|forced_src}` catalogs to `objectTable_tracts`.  I don't have any multiband output in a gen3 repo right now, so I'm excluding it from the DRP pipeline here until tested.  @taranu, you can remove this objectTable  exclusion if it works in your 3828 Gen3 DRP check. 