### PR TITLE
DM-30838: Disable configs and columns about bright object mask flags.

### DIFF
--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -31,9 +31,6 @@ config.load(os.path.join(os.path.dirname(__file__), "cmodel.py"))
 
 config.measurement.slots.gaussianFlux = None
 
-config.measurement.plugins['base_PixelFlags'].masksFpCenter.append('BRIGHT_OBJECT')
-config.measurement.plugins['base_PixelFlags'].masksFpAnywhere.append('BRIGHT_OBJECT')
-
 config.catalogCalculation.plugins.names = ["base_ClassificationExtendedness"]
 config.measurement.slots.psfFlux = "base_PsfFlux"
 

--- a/config/measureCoaddSources.py
+++ b/config/measureCoaddSources.py
@@ -36,12 +36,4 @@ config.connections.refCat = "cal_ref_cat"
 
 config.doWriteMatchesDenormalized = True
 
-#
-# This isn't good!  There appears to be no way to configure the base_PixelFlags measurement
-# algorithm based on a configuration parameter; see DM-4159 for a discussion.  The name
-# BRIGHT_MASK must match assembleCoaddConfig.brightObjectMaskName
-#
-config.measurement.plugins["base_PixelFlags"].masksFpCenter.append("BRIGHT_OBJECT")
-config.measurement.plugins["base_PixelFlags"].masksFpAnywhere.append("BRIGHT_OBJECT")
-
 config.measurement.plugins.names |= ["base_InputCount"]

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -331,8 +331,6 @@ flags:
     - base_Blendedness_flag
     - base_PixelFlags_flag
     - base_PixelFlags_flag_bad
-    - base_PixelFlags_flag_bright_object
-    - base_PixelFlags_flag_bright_objectCenter
     - base_PixelFlags_flag_clipped
     - base_PixelFlags_flag_clippedCenter
     - base_PixelFlags_flag_cr


### PR DESCRIPTION
DM-30649 fixed a config option in assembleCoadd that makes it so the BRIGHT_OBJECT mask plane does not exist, while before it was just never being set (because we don't have any bright object masks for non-HSC instruments, and we never will, at least not in this form).

But this broke downstream processing that expected this mask plane to exist.