### PR TITLE
DM-31228: Move some code to python logging

### DIFF
--- a/python/lsst/obs/lsst/assembly.py
+++ b/python/lsst/obs/lsst/assembly.py
@@ -22,16 +22,16 @@
 __all__ = ("attachRawWcsFromBoresight", "fixAmpGeometry", "assembleUntrimmedCcd",
            "fixAmpsAndAssemble", "readRawAmps")
 
+import logging
 from contextlib import contextmanager
 import numpy as np
-import lsst.log
 import lsst.afw.image as afwImage
 from lsst.obs.base import bboxFromIraf, MakeRawVisitInfoViaObsInfo, createInitialSkyWcs
 from lsst.geom import Box2I, Extent2I
 from lsst.ip.isr import AssembleCcdTask
 from astro_metadata_translator import ObservationInfo
 
-logger = lsst.log.Log.getLogger("obs.lsst.assembly")
+logger = logging.getLogger("obs.lsst.assembly")
 
 
 def attachRawWcsFromBoresight(exposure, dataIdForErrMsg=None):
@@ -223,9 +223,9 @@ def warn_once(msg):
     def logCmd(s, *args):
         nonlocal warned
         if warned:
-            logger.debug(f"{msg}: {s}", *args)
+            logger.debug("%s: %s", *args)
         else:
-            logger.warn(f"{msg}: {s}", *args)
+            logger.warning("%s: %s", *args)
             warned = True
 
     yield logCmd

--- a/python/lsst/obs/lsst/assembly.py
+++ b/python/lsst/obs/lsst/assembly.py
@@ -66,8 +66,8 @@ def attachRawWcsFromBoresight(exposure, dataIdForErrMsg=None):
         return True
 
     if obsInfo.observation_type == "science":
-        logger.warn("Unable to set WCS from header as RA/Dec/Angle are unavailable%s",
-                    ("" if dataIdForErrMsg is None else " for dataId %s" % dataIdForErrMsg))
+        logger.warning("Unable to set WCS from header as RA/Dec/Angle are unavailable%s",
+                       ("" if dataIdForErrMsg is None else " for dataId %s" % dataIdForErrMsg))
     return False
 
 

--- a/python/lsst/obs/lsst/ingest.py
+++ b/python/lsst/obs/lsst/ingest.py
@@ -19,11 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import re
 from lsst.pipe.tasks.ingest import ParseTask
 from lsst.pipe.tasks.ingestCalibs import CalibsParseTask
 from astro_metadata_translator import ObservationInfo
-import lsst.log as lsstLog
 from .translators import LsstCamTranslator
 from .lsstCamMapper import LsstCamMapper
 from ._fitsHeader import readRawFitsHeader
@@ -155,8 +155,8 @@ class LsstCamParseTask(ParseTask):
 
         wl = int(round(raw_wl))
         if abs(raw_wl-wl) >= 0.1:
-            logger = lsstLog.Log.getLogger('obs.lsst.ingest')
-            logger.warn(
+            logger = logging.getLogger('obs.lsst.ingest')
+            logger.warning(
                 'Translated significantly non-integer wavelength; '
                 '%s is more than 0.1nm from an integer value', raw_wl)
         return wl

--- a/python/lsst/obs/lsst/latiss.py
+++ b/python/lsst/obs/lsst/latiss.py
@@ -20,9 +20,9 @@
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
+import logging
 import os.path
 import re
-import lsst.log
 from . import LsstCamMapper, LsstCamMakeRawVisitInfo
 from .ingest import LsstCamParseTask
 from .translators import LatissTranslator
@@ -73,7 +73,7 @@ class LatissMapper(LsstCamMapper):
             if "controller" in dataId:
                 controller = dataId["controller"]
             else:
-                lsst.log.Log.getLogger("LsstLatissMapper").warn("Controller unknown, using 'C'")
+                logging.getLogger("LsstLatissMapper").warning("Controller unknown, using 'C'")
                 controller = "C"
             visit = LatissTranslator.compute_exposure_id(dataId['dayObs'], dataId["seqNum"],
                                                          controller)
@@ -81,8 +81,8 @@ class LatissMapper(LsstCamMapper):
         if "detector" in dataId:
             detector = dataId["detector"]
             if detector != 0:
-                lsst.log.Log.getLogger("LatissMapper").warn("Got detector %d for LATISS when it should"
-                                                            " always be 0", detector)
+                logging.getLogger("LatissMapper").warning("Got detector %d for LATISS when it should"
+                                                          " always be 0", detector)
         else:
             detector = 0
 
@@ -130,8 +130,8 @@ class LatissParseTask(LsstCamParseTask):
                 break
 
         if seqNum == 0:
-            logger = lsst.log.Log.getLogger('obs.lsst.LatissParseTask')
-            logger.warn(
+            logger = logging.getLogger('obs.lsst.LatissParseTask')
+            logger.warning(
                 'Could not determine sequence number. Assuming %d ', seqNum)
 
         return seqNum

--- a/python/lsst/obs/lsst/script/phosimToRafts.py
+++ b/python/lsst/obs/lsst/script/phosimToRafts.py
@@ -162,7 +162,7 @@ def processPhosimData(ids, visit, inputDir, outputDir):
 
         dataId["detector"] = detector   # more of the butler stupidity
 
-        logger.warn("Processing data from detector %s_%s", raftName, detectorName)
+        logger.warning("Processing data from detector %s_%s", raftName, detectorName)
 
         if raftName not in raftData:
             raftData[raftName] = {}

--- a/python/lsst/obs/lsst/translators/lsstCam.py
+++ b/python/lsst/obs/lsst/translators/lsstCam.py
@@ -96,8 +96,8 @@ class LsstCamTranslator(LsstBaseTranslator):
             ccdslot = header.get("CCDSLOT", "unknown")
             raftbay = header.get("RAFTBAY", "unknown")
 
-            log.warn("%s %s_%s: No FILTER key found but FILTER2=\"%s\" (removed)",
-                     log_label, raftbay, ccdslot, header["FILTER2"])
+            log.warning("%s %s_%s: No FILTER key found but FILTER2=\"%s\" (removed)",
+                        log_label, raftbay, ccdslot, header["FILTER2"])
             header["FILTER2"] = None
             modified = True
 


### PR DESCRIPTION
The gen2-specific code is still lsst.log.