### PR TITLE
DM-31445: Enable GAaP PSF photometry before apCorr

### DIFF
--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -75,6 +75,7 @@ if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
     config.measureApCorr.allowFailure += names
 
 if "ext_gaap_GaapFlux" in config.measurement.plugins:
+    config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
     names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
     config.measureApCorr.allowFailure += names
 

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -35,6 +35,9 @@ config.measurement.slots.gaussianFlux = None
 config.catalogCalculation.plugins.names = ["base_ClassificationExtendedness"]
 config.measurement.slots.psfFlux = "base_PsfFlux"
 
+# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
+
 def doUndeblended(config, algName, fluxList=None):
     """Activate undeblended measurements of algorithm
     Parameters
@@ -65,5 +68,3 @@ doUndeblended(config, "ext_gaap_GaapFlux",
 # Disable registration for apCorr of undeblended convolved; apCorr will be done through the deblended proxy
 config.measurement.undeblended["ext_convolved_ConvolvedFlux"].registerForApCorr = False
 config.measurement.undeblended["ext_gaap_GaapFlux"].registerForApCorr = False
-# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
-config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True


### PR DESCRIPTION
`doPsfPhotometry` must be set to `True` prior to registering the plugin for
aperture corrections.