### PR TITLE
DM-31760: Single amp reads for obs_lsst have the wrong geometry.

### DIFF
--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -178,7 +178,7 @@ class LsstCamRawFormatter(FitsRawFormatterBase):
                 # on-disk amplifier to have the same orientation and offsets as
                 # the given one.
                 adjusted_amplifier_builder.transform(
-                    outOffset=amplifier.getRawXYOffset(),
+                    outOffset=adjusted_amplifier_builder.getRawXYOffset(),
                     outFlipX=amplifier.getRawFlipX(),
                     outFlipY=amplifier.getRawFlipY(),
                 )

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -178,7 +178,7 @@ class LsstCamRawFormatter(FitsRawFormatterBase):
                 # on-disk amplifier to have the same orientation and offsets as
                 # the given one.
                 adjusted_amplifier_builder.transform(
-                    outOffset=adjusted_amplifier_builder.getRawXYOffset(),
+                    outOffset=on_disk_amplifier.getRawXYOffset(),
                     outFlipX=amplifier.getRawFlipX(),
                     outFlipY=amplifier.getRawFlipY(),
                 )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -83,10 +83,8 @@ class LatissIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase):
                 # comes straight from the camera) won't have those patches, so
                 # we can't compare it to the amp attached to
                 # unassembled_subimage (which does have those patches).
-                # Instead we test that these two have the same
-                # assembly/orientation:
                 comparison2 = unassembled_subimage.getDetector()[0].compareGeometry(unassembled_amp)
-                self.assertFalse(comparison2 & AmplifierGeometryComparison.ASSEMBLY_DIFFERS)
+
                 self.assertTrue(comparison2 & AmplifierGeometryComparison.REGIONS_DIFFER)
                 # ...and that unassembled_subimage's amp has the same regions
                 # (after accounting for assembly/orientation) as assembled_amp.


### PR DESCRIPTION
Fix transform for single-amp reads.

If the detector has been modified, then any transforms need to be
relative to the new XY offset position that is calculated during that
modification.