### PR TITLE
DM-31825: Implement RFC-807 on DRP parquet table consistency

### DIFF
--- a/pipelines/imsim/DRP.yaml
+++ b/pipelines/imsim/DRP.yaml
@@ -115,6 +115,8 @@ subsets:
         - forcedPhotDiffOnDiaObjects
         - transformForcedSourceTable
         - consolidateForcedSourceTable
+        - consolidateAssocDiaSourceTable
+        - consolidateFullDiaObjectTable
         - writeForcedSourceOnDiaObjectTable
         - transformForcedSourceOnDiaObjectTable
         - consolidateForcedSourceOnDiaObjectTable

--- a/policy/imsim/ForcedSource.yaml
+++ b/policy/imsim/ForcedSource.yaml
@@ -1,4 +1,8 @@
 funcs:
+    forcedSourceId:
+        functor: Column
+        args: id
+        dataset: calexp
     parentObjectId:
         functor: Column
         args: parent
@@ -21,7 +25,7 @@ funcs:
         functor: Column
         dataset: calexp
         args: band
-    PsFlux:
+    psfFlux:
         functor: LocalNanojansky
         dataset: calexp
         args:
@@ -29,7 +33,7 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsFluxErr:
+    psfFluxErr:
         functor: LocalNanojanskyErr
         dataset: calexp
         args:
@@ -37,19 +41,11 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsFluxFlag:
+    psfFluxFlag:
         functor: Column
         dataset: calexp
         args: base_PsfFlux_flag
-    psFluxApCorr:
-        functor: Column
-        dataset: calexp
-        args: base_PsfFlux_apCorr
-    psFluxApCorrErr:
-        functor: Column
-        dataset: calexp
-        args: base_PsfFlux_apCorrErr
-    PsDiffFlux:
+    psfDiffFlux:
         functor: LocalNanojansky
         dataset: diff
         args:
@@ -57,7 +53,7 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsDiffFluxErr:
+    psfDiffFluxErr:
         functor: LocalNanojanskyErr
         dataset: diff
         args:
@@ -65,23 +61,22 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsDiffFluxFlag:
+    psfDiffFluxFlag:
         functor: Column
         dataset: diff
         args: base_PsfFlux_flag
-    psDiffFluxApCorr:
-        functor: Column
-        dataset: diff
-        args: base_PsfFlux_apCorr
-    psDiffFluxApCorrErr:
-        functor: Column
-        dataset: diff
-        args: base_PsfFlux_apCorrErr
 # PixelFlags exist in forced_src and forced_diff dataset, but they're all False
 calexpFlags:
+    - base_LocalPhotoCalib
+    - base_LocalPhotoCalib_flag
+    - base_LocalPhotoCalibErr
+    - base_LocalWcs_flag
+    - base_LocalWcs_CDMatrix_2_1
+    - base_LocalWcs_CDMatrix_1_1
+    - base_LocalWcs_CDMatrix_1_2
+    - base_LocalWcs_CDMatrix_2_2
     - base_LocalBackground_instFlux
     - base_LocalBackground_instFluxErr
-    - base_PixelFlags_flag
     - base_PixelFlags_flag_edge
     - base_PixelFlags_flag_interpolated
     - base_PixelFlags_flag_saturated
@@ -94,4 +89,4 @@ calexpFlags:
     - base_PixelFlags_flag_suspectCenter
 flag_rename_rules:
     - ['base_PixelFlags_flag', 'pixelFlags']
-    - ['base_LocalBackground', 'localBackground']
+    - ['base_Local', 'local']

--- a/policy/imsim/ForcedSource.yaml
+++ b/policy/imsim/ForcedSource.yaml
@@ -13,7 +13,7 @@ funcs:
         dataset: calexp
         args: coord_ra
     coord_dec:
-         # reference position required by database. Not in DPDD
+        # reference position required by database. Not in DPDD
         functor: CoordColumn
         dataset: calexp
         args: coord_dec
@@ -41,7 +41,7 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    psfFluxFlag:
+    psfFlux_flag:
         functor: Column
         dataset: calexp
         args: base_PsfFlux_flag
@@ -61,7 +61,7 @@ funcs:
             - base_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    psfDiffFluxFlag:
+    psfDiffFlux_flag:
         functor: Column
         dataset: diff
         args: base_PsfFlux_flag

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -36,7 +36,7 @@ funcs:
     # psParallax: No moving point source model yet
     psfFlux:
         functor: NanoJansky
-        dataset: forced_src  # recommend including meas too
+        dataset: forced_src
         args: slot_PsfFlux_instFlux
     psfFluxErr:
         functor: NanoJanskyErr
@@ -44,6 +44,20 @@ funcs:
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
+    free_psfFlux:
+        functor: NanoJansky
+        dataset: meas
+        args: slot_PsfFlux_instFlux
+    free_psfFluxErr:
+        functor: NanoJanskyErr
+        dataset: meas
+        args:
+            - slot_PsfFlux_instFlux
+            - slot_PsfFlux_instFluxErr
+    free_psfFlux_flag:
+        functor: Column
+        dataset: meas
+        args: slot_PsfFlux_flag
     # Assume the database will provide UDFs for Mags
     # psCov:
     #     Flux should be somewhere in the name?
@@ -59,6 +73,9 @@ funcs:
     # In the meantime, CModel is the best
     # CModel fluxes have alias slot_ModelFlux
     # bdRadec: # Same as SdssCentroid
+    # AB + theta
+    # E1+Re in DPDD is for a reason is no longer valid
+    # We once thought we were going to do shear from these.
     bdE1:
         functor: E1
         dataset: meas
@@ -131,11 +148,11 @@ funcs:
     # izStd:
     # zyStd:
     #  PSF GAaP flux
-    gaapFlux_Psf:
+    gaapFlux_psf:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_PsfFlux_instFlux
-    gaapFluxErr_Psf:
+    gaapFluxErr_psf:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
@@ -164,16 +181,20 @@ funcs:
             - ext_gaap_GaapFlux_1_15x_1_0_instFlux
             - ext_gaap_GaapFlux_1_15x_1_0_instFluxErr
     #  Optimal GAaP flux
-    gaapFlux_Optimal:
+    gaapFlux_optimal:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_Optimal_instFlux
-    gaapFluxErr_Optimal:
+    gaapFluxErr_optimal:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_Optimal_instFlux
             - ext_gaap_GaapFlux_1_15x_Optimal_instFluxErr
+    gaapFlux_optimal_flag_bigPsf:
+        functor: Column
+        dataset: forced_src
+        args: ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
     # Taking Shape from meas
     ixx:
         functor: Column
@@ -186,6 +207,10 @@ funcs:
     ixy:
         functor: Column
         args: slot_Shape_xy
+        dataset: meas
+    i_flag:
+        functor: Column
+        args: slot_Shape_flag
         dataset: meas
     # Icov: # need to compute
     # DM-22249 Evaluate whether we want to replace IxxPSF/IyyPSF/IxyPSF w/ FWHM
@@ -200,6 +225,46 @@ funcs:
     ixyPSF:
         functor: Column
         args: slot_PsfShape_xy
+        dataset: meas
+    iPSF_flag:
+        functor: Column
+        args: slot_PsfShape_flag
+        dataset: meas
+    ixxRound:
+        functor: Column
+        args: slot_ShapeRound_xx
+        dataset: meas
+    iyyRound:
+        functor: Column
+        args: slot_ShapeRound_yy
+        dataset: meas
+    ixyRound:
+        functor: Column
+        args: slot_ShapeRound_xy
+        dataset: meas
+    iRound_flag:
+        functor: Column
+        args: slot_ShapeRound_xy
+        dataset: meas
+    iPSF_flag:
+        functor: Column
+        args: slot_PsfShape_flag
+        dataset: meas
+    ixxDebiasedPSF:
+        functor: Column
+        args: ext_shapeHSM_HsmPsfMomentsDebiased_xx
+        dataset: meas
+    iyyDebiasedPSF:
+        functor: Column
+        args: ext_shapeHSM_HsmPsfMomentsDebiased_yy
+        dataset: meas
+    ixyDebiasedPSF:
+        functor: Column
+        args:  ext_shapeHSM_HsmPsfMomentsDebiased_xy
+        dataset: meas
+    iDebiasedPSF_flag:
+        functor: Column
+        args: ext_shapeHSM_HsmPsfMomentsDebiased_flag
         dataset: meas
     # m4: Request removal from DPDD (DM-22250)
     # Petrosian magnitudes not yet implemented. Planning pacakge DMBP-116
@@ -234,11 +299,12 @@ funcs:
     # kronRad50Err: Need to compute DM-16313
     # kronRad90: Need to compute DM-16313
     # kronRad90Err: Need to compute DM-16313
-    apFlux:
+    # apFlux renamed to calibFlux because it is not guaranteed to be an apFlux
+    calibFlux:
         functor: NanoJansky
         dataset: meas
         args: slot_CalibFlux_instFlux
-    apFluxErr:
+    calibFluxErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
@@ -259,6 +325,7 @@ funcs:
         functor: Column
         dataset: forced_src
         args: base_CircularApertureFlux_3_0_flag
+    # if we need to add decimal apertures call them e.g. ap04p5Flux
     ap06Flux:
         functor: NanoJansky
         dataset: forced_src
@@ -287,6 +354,20 @@ funcs:
         functor: Column
         dataset: forced_src
         args: base_CircularApertureFlux_9_0_flag
+    ap12Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_12_0_instFlux
+    ap12FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_12_0_instFlux
+            - base_CircularApertureFlux_12_0_instFluxErr
+    ap12Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_12_0_flag
     ap17Flux:
         functor: NanoJansky
         dataset: forced_src
@@ -408,14 +489,36 @@ funcs:
         functor: HsmFwhm
     cModelFlux:
         functor: NanoJansky
-        dataset: meas
+        dataset: forced_src
         args: modelfit_CModel_instFlux
     cModelFluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - modelfit_CModel_instFlux
+            - modelfit_CModel_instFluxErr
+    cModelFlux_inner:
+        functor: NanoJansky
+        dataset: forced_src
+        args: modelfit_CModel_instFlux_inner
+    free_cModelFlux: #to dm-naming things
+        functor: NanoJansky
+        dataset: meas
+        args: modelfit_CModel_instFlux
+    free_cModelFluxErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
             - modelfit_CModel_instFlux
             - modelfit_CModel_instFluxErr
+    free_cModelFlux_inner:
+        functor: NanoJansky
+        dataset: meas
+        args: modelfit_CModel_instFlux_inner
+    free_cModelFlux_flag:
+        functor: Column
+        dataset: meas
+        args: modelfit_CModel_flag
     # exp, dev, total, fracdev
     # We need different ellipticities for shear measurement:
     hsmShapeRegauss_e1:
@@ -426,6 +529,10 @@ funcs:
         functor: Column
         args: ext_shapeHSM_HsmShapeRegauss_e2
         dataset: meas
+    hsmShapeRegauss_sigma:
+        functor: Column
+        args: ext_shapeHSM_HsmShapeRegauss_sigma
+        dataset: meas
     hsmShapeRegauss_flag:
         functor: Column
         args: ext_shapeHSM_HsmShapeRegauss_flag
@@ -433,7 +540,15 @@ funcs:
     inputCount:
         functor: Column
         args: base_InputCount_value
-        dataset: meas
+        dataset: forced_src
+    footprintArea:
+        functor: Column
+        args: base_FootprintArea_value
+        dataset: ref
+    sky_object:
+        functor: Column
+        args: merge_peak_sky
+        dataset: ref
     # DM-22247: Add Star/Galaxy sep olumns
     #     - Morphological Star Galaxy Classifier (Names? float 0-1)]
     #     - Morphological + Color (SED-based) Star Galaxy Classifier (Names? float 0-1)]
@@ -448,11 +563,14 @@ refFlags:
     - detect_isDeblendedSource
     - detect_isDeblendedModelSource
     - merge_peak_sky
-    - calib_psf_used
-flags:
-    # flags are columns taken and exploded per-band from the meas tables
     - deblend_nChild
     - deblend_skipped
+    - slot_Shape_flag
+    - slot_Shape_xx
+    - slot_Shape_xy
+    - slot_Shape_yy
+flags:
+    # flags are columns taken and exploded per-band from the meas tables
     - base_Blendedness_flag
     - base_PixelFlags_flag_bad
     - base_PixelFlags_flag_clipped
@@ -472,8 +590,6 @@ flags:
     - base_PixelFlags_flag_suspect
     - base_PixelFlags_flag_suspectCenter
     - base_ClassificationExtendedness_flag
-    - base_InputCount_flag
-    - base_InputCount_flag_noInputs
     - calib_astrometry_used
     - calib_photometry_reserved
     - calib_photometry_used
@@ -486,29 +602,11 @@ flags:
     - slot_CalibFlux_flag
     - slot_CalibFlux_flag_apertureTruncated
     - slot_CalibFlux_flag_sincCoeffsTruncated
-    - slot_Centroid_flag_almostNoSecondDerivative
-    - slot_Centroid_flag_edge
-    - slot_Centroid_flag_noSecondDerivative
-    - slot_Centroid_flag_notAtMaximum
-    - slot_Centroid_flag_resetToPeak
-    - slot_ShapeRound_flag
-    - slot_ShapeRound_flag_no_pixels
-    - slot_ShapeRound_flag_not_contained
-    - slot_ShapeRound_flag_parent_source
-    - slot_ShapeRound_Flux
-    - slot_ShapeRound_x
-    - slot_ShapeRound_xx
-    - slot_ShapeRound_xy
-    - slot_ShapeRound_y
-    - slot_ShapeRound_yy
-    - slot_PsfShape_flag
-    - slot_PsfShape_flag_no_pixels
-    - slot_PsfShape_flag_not_contained
-    - slot_PsfShape_flag_parent_source
-    - slot_Shape_flag
-    - slot_Shape_flag_no_pixels
-    - slot_Shape_flag_not_contained
-    - slot_Shape_flag_parent_source
+    - slot_Centroid_flag
+    - slot_Centroid_x
+    - slot_Centroid_xErr
+    - slot_Centroid_y
+    - slot_Centroid_yErr
     - ext_photometryKron_KronFlux_flag
     - ext_photometryKron_KronFlux_flag_bad_radius
     - ext_photometryKron_KronFlux_flag_bad_shape
@@ -521,23 +619,25 @@ flags:
     - ext_photometryKron_KronFlux_flag_used_psf_radius
 forcedFlags:
     # - forced source
+    - base_InputCount_flag
+    - base_InputCount_flag_noInputs
     - slot_PsfFlux_area
     - slot_PsfFlux_flag
     - slot_PsfFlux_flag_apCorr
     - slot_PsfFlux_flag_edge
     - slot_PsfFlux_flag_noGoodPixels
+    - modelfit_CModel_flag
+    - modelfit_CModel_flag_apCorr
     - ext_gaap_GaapFlux_flag
     - ext_gaap_GaapFlux_flag_edge
     - ext_gaap_GaapFlux_1_15x_flag_gaussianization
-    - ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
     - ext_gaap_GaapFlux_1_15x_0_7_flag_bigPsf
     - ext_gaap_GaapFlux_1_15x_1_0_flag_bigPsf
 flag_rename_rules:
     # Taken from db-meas-forced
-    - ['modelfit_', '']
+    - ['modelfit_C', 'c']
     - ['base_PixelFlags_flag', 'pixelFlags']
     - ['base_CircularApertureFlux', 'apFlux']
-    - ['ext_shapeHSM_Hsm', 'hsm']
     - ['ext_convolved_', '']
     - ['ext_gaap_GaapFlux_1_15x', 'gaapFlux']
     - ['ext_gaap_GaapFlux', 'gaapFlux']
@@ -548,7 +648,6 @@ flag_rename_rules:
     - ['slot_Calib', 'calib']
     - ['slot_Psf', 'psf']
     - ['slot_Shape', 'shape']
-    - ['slot_Psf', 'psf']
     - ['slot_ApFlux', 'apFlux']
     - ['base_Blendedness', 'blendedness']
     - ['base_PixelFlags_flag', 'pixelFlags']

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -14,11 +14,11 @@ funcs:
         # coord_dec because "dec" is reserved in most SQL DBs
         functor: DecColumn
         dataset: ref
-    Ra:
+    ra:
         functor: CoordColumn
         args: coord_ra
         dataset: meas
-    Decl:
+    decl:
         functor: CoordColumn
         args: coord_dec
         dataset: meas
@@ -34,11 +34,11 @@ funcs:
     # psRadec: No moving point source model yet
     # psPm: No moving point source model yet
     # psParallax: No moving point source model yet
-    PsFlux:
+    psfFlux:
         functor: NanoJansky
         dataset: forced_src  # recommend including meas too
         args: slot_PsfFlux_instFlux
-    PsFluxErr:
+    psfFluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
@@ -59,30 +59,30 @@ funcs:
     # In the meantime, CModel is the best
     # CModel fluxes have alias slot_ModelFlux
     # bdRadec: # Same as SdssCentroid
-    BdE1:
+    bdE1:
         functor: E1
         dataset: meas
         args:
             - modelfit_CModel_ellipse_xx
             - modelfit_CModel_ellipse_xy
             - modelfit_CModel_ellipse_yy
-    # rBdE1Err:  Not computed
-    BdE2:
+    # rbdE1Err:  Not computed
+    bdE2:
         functor: E2
         dataset: meas
         args:
             - modelfit_CModel_ellipse_xx
             - modelfit_CModel_ellipse_xy
             - modelfit_CModel_ellipse_yy
-    # rBdE2Err:  Not computed
-    BdReB:
+    # rbdE2Err:  Not computed
+    bdReB:
         functor: RadiusFromQuadrupole
         dataset: meas
         args:
             - modelfit_CModel_dev_ellipse_xx
             - modelfit_CModel_dev_ellipse_xy
             - modelfit_CModel_dev_ellipse_yy
-    BdReD:
+    bdReD:
         functor: RadiusFromQuadrupole
         dataset: meas
         args:
@@ -93,27 +93,27 @@ funcs:
     # DM-22251: We need a total galaxy model (BD) flux column:
     # with either a total and fraction in Bulge or Disk
     # We should change the name BD, it assumes algorithm choice
-    BdChi2:
+    bdChi2:
         functor: Column
         dataset: meas
         args: modelfit_CModel_objective
     # bdSamples: DM-22242 Remove from the DPDD and
     # replace with other shear estimation parameters. e.g. How e1 and e2 respond to shear.
-    BdFluxB:
+    bdFluxB:
         functor: NanoJansky
         dataset: meas
         args: modelfit_CModel_dev_instFlux
-    BdFluxBErr:
+    bdFluxBErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
             - modelfit_CModel_dev_instFlux
             - modelfit_CModel_dev_instFluxErr
-    BdFluxD:
+    bdFluxD:
         functor: NanoJansky
         dataset: meas
         args: modelfit_CModel_exp_instFlux
-    BdFluxDErr:
+    bdFluxDErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
@@ -121,103 +121,83 @@ funcs:
             - modelfit_CModel_exp_instFluxErr
     # DM-22243: Replace these with g, r, i, z, y and the blessed fluxes to use for colors
     # Need a new name like "gModelColorFlux", "gMatchedApertureGalaxyFlux", or
-    # "gMatchedApertureFlux"
+    # "gMatchedApertureFlux", "gStdFlux"
         # HSC users still debating between
         #  1) PSF convolved undeblended aperture fluxes?
         #  2) Scarlet outputs?
         # In the meantime use forced CModel
-    grStd:
-        functor: Color
-        dataset: forced_src
-        args: slot_ModelFlux
-        filt1: g
-        filt2: r
-    riStd:
-        functor: Color
-        dataset: forced_src
-        args: slot_ModelFlux
-        filt1: r
-        filt2: i
-    izStd:
-        functor: Color
-        dataset: forced_src
-        args: slot_ModelFlux
-        filt1: i
-        filt2: z
-    zyStd:
-        functor: Color
-        dataset: forced_src
-        args: slot_ModelFlux
-        filt1: z
-        filt2: y
+    # grStd:
+    # riStd:
+    # izStd:
+    # zyStd:
     #  PSF GAaP flux
-    GaapFlux_Psf:
+    gaapFlux_Psf:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_PsfFlux_instFlux
-    GaapFluxErr_Psf:
+    gaapFluxErr_Psf:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_PsfFlux_instFlux
             - ext_gaap_GaapFlux_1_15x_PsfFlux_instFluxErr
     # 0.7 arcsec sigma GAaP flux
-    GaapFlux_0_7:
+    gaapFlux_0_7:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_0_7_instFlux
-    GaapFluxErr_0_7:
+    gaapFluxErr_0_7:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_0_7_instFlux
             - ext_gaap_GaapFlux_1_15x_0_7_instFluxErr
     # 1.0 arcsec sigma GAaP flux
-    GaapFlux_1_0:
+    gaapFlux_1_0:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_1_0_instFlux
-    GaapFluxErr_1_0:
+    gaapFluxErr_1_0:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_1_0_instFlux
             - ext_gaap_GaapFlux_1_15x_1_0_instFluxErr
     #  Optimal GAaP flux
-    GaapFlux_Optimal:
+    gaapFlux_Optimal:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_Optimal_instFlux
-    GaapFluxErr_Optimal:
+    gaapFluxErr_Optimal:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_Optimal_instFlux
             - ext_gaap_GaapFlux_1_15x_Optimal_instFluxErr
     # Taking Shape from meas
-    Ixx:
+    ixx:
         functor: Column
         args: slot_Shape_xx
         dataset: meas
-    Iyy:
+    iyy:
         functor: Column
         args: slot_Shape_yy
         dataset: meas
-    Ixy:
+    ixy:
         functor: Column
         args: slot_Shape_xy
         dataset: meas
     # Icov: # need to compute
     # DM-22249 Evaluate whether we want to replace IxxPSF/IyyPSF/IxyPSF w/ FWHM
-    IxxPsf:
+    ixxPSF:
         functor: Column
         args: slot_PsfShape_xx
         dataset: meas
-    IyyPsf:
+    iyyPSF:
         functor: Column
         args: slot_PsfShape_yy
         dataset: meas
-    IxyPsf:
+    ixyPSF:
         functor: Column
         args: slot_PsfShape_xy
         dataset: meas
@@ -233,18 +213,18 @@ funcs:
     # petroRad50Err:
     # petroRad90:
     # petroRad90Err:
-    KronRad:
+    kronRad:
         # Convert to sky coords
         functor: Column
         args: ext_photometryKron_KronFlux_radius
         dataset: meas  # or forced_src?
     # kronRadErr: # Not computed
     # kronBand: replaced with `refBand`
-    KronFlux:
+    kronFlux:
         functor: NanoJansky
         dataset: meas  # or forced_src?
         args: ext_photometryKron_KronFlux_instFlux
-    KronFluxErr:
+    kronFluxErr:
         functor: NanoJanskyErr
         dataset: meas  # or forced_src?
         args:
@@ -254,37 +234,130 @@ funcs:
     # kronRad50Err: Need to compute DM-16313
     # kronRad90: Need to compute DM-16313
     # kronRad90Err: Need to compute DM-16313
-    ApFlux:
+    apFlux:
         functor: NanoJansky
         dataset: meas
         args: slot_CalibFlux_instFlux
-    ApFluxErr:
+    apFluxErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
     # Not in DPDD. Used for QA
-    Ap25Flux:
+    ap03Flux:
         functor: NanoJansky
         dataset: forced_src
-        args: base_CircularApertureFlux_25_0_instFlux
-    Ap25FluxErr:
+        args: base_CircularApertureFlux_3_0_instFlux
+    ap03FluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
-            - base_CircularApertureFlux_25_0_instFlux
-            - base_CircularApertureFlux_25_0_instFluxErr
-    Ap9Flux:
+            - base_CircularApertureFlux_3_0_instFlux
+            - base_CircularApertureFlux_3_0_instFluxErr
+    ap03Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_3_0_flag
+    ap06Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_6_0_instFlux
+    ap06FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_6_0_instFlux
+            - base_CircularApertureFlux_6_0_instFluxErr
+    ap06Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_6_0_flag
+    ap09Flux:
         functor: NanoJansky
         dataset: forced_src
         args: base_CircularApertureFlux_9_0_instFlux
-    Ap9FluxErr:
+    ap09FluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - base_CircularApertureFlux_9_0_instFlux
             - base_CircularApertureFlux_9_0_instFluxErr
+    ap09Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_9_0_flag
+    ap17Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_17_0_instFlux
+    ap17FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_17_0_instFlux
+            - base_CircularApertureFlux_17_0_instFluxErr
+    ap17Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_17_0_flag
+    ap25Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_25_0_instFlux
+    ap25FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_25_0_instFlux
+            - base_CircularApertureFlux_25_0_instFluxErr
+    ap25Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_25_0_flag
+    ap35Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_35_0_instFlux
+    ap35FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_35_0_instFlux
+            - base_CircularApertureFlux_35_0_instFluxErr
+    ap35Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_35_0_flag
+    ap50Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_50_0_instFlux
+    ap50FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_50_0_instFlux
+            - base_CircularApertureFlux_50_0_instFluxErr
+    ap50Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_50_0_flag
+    ap70Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: base_CircularApertureFlux_70_0_instFlux
+    ap70FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - base_CircularApertureFlux_70_0_instFlux
+            - base_CircularApertureFlux_70_0_instFluxErr
+    ap70Flux_flag:
+        functor: Column
+        dataset: forced_src
+        args: base_CircularApertureFlux_70_0_flag
+
     # DM-22246: Change Ap surface brightness to fluxes in DPDD
     # i.e. remove apNann, apMeanSb, apMeanSbSigma
     # DM-22247: Replace Extendedness with a view or paragraph in docs on how to compute
@@ -292,7 +365,7 @@ funcs:
         functor: Column
         args: base_ClassificationExtendedness_value
         dataset: ref
-    Extendedness:
+    extendedness:
         functor: Column
         args: base_ClassificationExtendedness_value
         dataset: meas
@@ -322,22 +395,22 @@ funcs:
         args: slot_Centroid_flag
         dataset: ref
     # Not in DPDD
-    Blendedness:
+    blendedness:
         functor: Column
         args: base_Blendedness_abs
         dataset: meas
     # DM-22249: Make FWHM a view of IxxPsf IxyPsf IyyPsf
     # Or remove ixxPsf, IxyPsf, IyyPsf.
-    Fwhm:
+    fwhm:
         functor: HsmFwhm
         dataset: meas
     refFwhm:
         functor: HsmFwhm
-    CModelFlux:
+    cModelFlux:
         functor: NanoJansky
         dataset: meas
         args: modelfit_CModel_instFlux
-    CModelFluxErr:
+    cModelFluxErr:
         functor: NanoJanskyErr
         dataset: meas
         args:
@@ -345,19 +418,19 @@ funcs:
             - modelfit_CModel_instFluxErr
     # exp, dev, total, fracdev
     # We need different ellipticities for shear measurement:
-    HsmShapeRegauss_e1:
+    hsmShapeRegauss_e1:
         functor: Column
         args: ext_shapeHSM_HsmShapeRegauss_e1
         dataset: meas
-    HsmShapeRegauss_e2:
+    hsmShapeRegauss_e2:
         functor: Column
         args: ext_shapeHSM_HsmShapeRegauss_e2
         dataset: meas
-    HsmShapeRegauss_flag:
+    hsmShapeRegauss_flag:
         functor: Column
         args: ext_shapeHSM_HsmShapeRegauss_flag
         dataset: meas
-    InputCount:
+    inputCount:
         functor: Column
         args: base_InputCount_value
         dataset: meas
@@ -367,8 +440,6 @@ funcs:
     # DM-22248: Need to add per object Galactic extinction to post-processing
 refFlags:
     # refFlags are columns taken without translation from the ref table
-    - tractId
-    - patchId
     - detect_isPatchInner
     - detect_isPrimary
     - detect_isTractInner
@@ -383,7 +454,6 @@ flags:
     - deblend_nChild
     - deblend_skipped
     - base_Blendedness_flag
-    - base_PixelFlags_flag
     - base_PixelFlags_flag_bad
     - base_PixelFlags_flag_clipped
     - base_PixelFlags_flag_clippedCenter
@@ -439,33 +509,7 @@ flags:
     - slot_Shape_flag_no_pixels
     - slot_Shape_flag_not_contained
     - slot_Shape_flag_parent_source
-forcedFlags:
-    # - forced source
-    - slot_PsfFlux_apCorr
-    - slot_PsfFlux_apCorrErr
-    - slot_PsfFlux_area
-    - slot_PsfFlux_flag
-    - slot_PsfFlux_flag_apCorr
-    - slot_PsfFlux_flag_edge
-    - slot_PsfFlux_flag_noGoodPixels
-    - ext_gaap_GaapFlux_1_15x_Psf_apCorr
-    - ext_gaap_GaapFlux_1_15x_Psf_apCorrErr
-    - ext_gaap_GaapFlux_1_15x_Optimal_apCorr
-    - ext_gaap_GaapFlux_1_15x_Optimal_apCorrErr
-    - ext_gaap_GaapFlux_1_15x_0_7_apCorr
-    - ext_gaap_GaapFlux_1_15x_0_7_apCorrErr
-    - ext_gaap_GaapFlux_1_15x_1_0_apCorr
-    - ext_gaap_GaapFlux_1_15x_1_0_apCorrErr
-    - ext_gaap_GaapFlux_flag
-    - ext_gaap_GaapFlux_flag_edge
-    - ext_gaap_GaapFlux_1_15x_flag_gaussianization
-    - ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
-    - ext_gaap_GaapFlux_1_15x_0_7_flag_bigPsf
-    - ext_gaap_GaapFlux_1_15x_1_0_flag_bigPsf
-    - ext_photometryKron_KronFlux_apCorr
-    - ext_photometryKron_KronFlux_apCorrErr
     - ext_photometryKron_KronFlux_flag
-    - ext_photometryKron_KronFlux_flag_apCorr
     - ext_photometryKron_KronFlux_flag_bad_radius
     - ext_photometryKron_KronFlux_flag_bad_shape
     - ext_photometryKron_KronFlux_flag_bad_shape_no_psf
@@ -475,23 +519,43 @@ forcedFlags:
     - ext_photometryKron_KronFlux_flag_small_radius
     - ext_photometryKron_KronFlux_flag_used_minimum_radius
     - ext_photometryKron_KronFlux_flag_used_psf_radius
+forcedFlags:
+    # - forced source
+    - slot_PsfFlux_area
+    - slot_PsfFlux_flag
+    - slot_PsfFlux_flag_apCorr
+    - slot_PsfFlux_flag_edge
+    - slot_PsfFlux_flag_noGoodPixels
+    - ext_gaap_GaapFlux_flag
+    - ext_gaap_GaapFlux_flag_edge
+    - ext_gaap_GaapFlux_1_15x_flag_gaussianization
+    - ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_0_7_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_1_0_flag_bigPsf
 flag_rename_rules:
     # Taken from db-meas-forced
-    - ['ext_photometryKron_', '']
     - ['modelfit_', '']
-    - ['base_PixelFlags_flag', 'PixelFlags']
-    - ['base_Classification', '']
-    - ['base_Sdss', '']
-    - ['base_CircularApertureFlux', 'ApFlux']
-    - ['ext_shapeHSM_', '']
+    - ['base_PixelFlags_flag', 'pixelFlags']
+    - ['base_CircularApertureFlux', 'apFlux']
+    - ['ext_shapeHSM_Hsm', 'hsm']
     - ['ext_convolved_', '']
-    - ['ext_gaap_GaapFlux_1_15x', 'GaapFlux']
-    - ['ext_gaap_GaapFlux', 'GaapFlux']
+    - ['ext_gaap_GaapFlux_1_15x', 'gaapFlux']
+    - ['ext_gaap_GaapFlux', 'gaapFlux']
     - ['undeblended_base', 'undeblended']
     - ['undeblended_ext_photometryKron', 'undeblended']
-    - ['ext_photometryKron_', '']
-    - ['base_', '']
-    - ['slot_', '']
-    - ['calib_', 'Calib_']
-    - ['deblend_', 'Deblend_']
-    - ['blendedness', 'Blendedness']
+    - ['ext_photometryKron_KronFlux', 'kronFlux']
+    - ['slot_Centroid', 'centroid']
+    - ['slot_Calib', 'calib']
+    - ['slot_Psf', 'psf']
+    - ['slot_Shape', 'shape']
+    - ['slot_Psf', 'psf']
+    - ['slot_ApFlux', 'apFlux']
+    - ['base_Blendedness', 'blendedness']
+    - ['base_PixelFlags_flag', 'pixelFlags']
+    - ['base_ClassificationE', 'e']
+    - ['base_Psf', 'psf']
+    - ['base_CircularApertureFlux', 'apFlux']
+    - ['base_FootprintArea', 'footprintArea']
+    - ['base_Jacobian', 'jacobian']
+    - ['base_Input', 'input']
+    - ['ext_convolved_', '']

--- a/policy/imsim/Source.yaml
+++ b/policy/imsim/Source.yaml
@@ -39,20 +39,121 @@ funcs:
     # declErr: not available yet DM-15180
     # ra_decl_Cov: not available yet
     # One calibrated Calib flux is important:
-    apFlux:
+    calibFlux:
         functor: LocalNanojansky
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    apFluxErr:
+    calibFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
+   # Not in DPDD. Used for QA
+    ap03Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_3_0_instFlux
+    ap03FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_3_0_instFlux
+            - base_CircularApertureFlux_3_0_instFluxErr
+    ap03Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_3_0_flag
+    # if we need to add decimal apertures call them e.g. ap04p5Flux
+    ap06Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_6_0_instFlux
+    ap06FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_6_0_instFlux
+            - base_CircularApertureFlux_6_0_instFluxErr
+    ap06Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_6_0_flag
+    ap09Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_9_0_instFlux
+    ap09FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_9_0_instFlux
+            - base_CircularApertureFlux_9_0_instFluxErr
+    ap09Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_9_0_flag
+    ap12Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_12_0_instFlux
+    ap12FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_12_0_instFlux
+            - base_CircularApertureFlux_12_0_instFluxErr
+    ap12Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_12_0_flag
+    ap17Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_17_0_instFlux
+    ap17FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_17_0_instFlux
+            - base_CircularApertureFlux_17_0_instFluxErr
+    ap17Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_17_0_flag
+    ap25Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_25_0_instFlux
+    ap25FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_25_0_instFlux
+            - base_CircularApertureFlux_25_0_instFluxErr
+    ap25Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_25_0_flag
+    ap35Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_35_0_instFlux
+    ap35FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_35_0_instFlux
+            - base_CircularApertureFlux_35_0_instFluxErr
+    ap35Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_35_0_flag
+    ap50Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_50_0_instFlux
+    ap50FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_50_0_instFlux
+            - base_CircularApertureFlux_50_0_instFluxErr
+    ap50Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_50_0_flag
+    ap70Flux:
+        functor: NanoJansky
+        args: base_CircularApertureFlux_70_0_instFlux
+    ap70FluxErr:
+        functor: NanoJanskyErr
+        args:
+            - base_CircularApertureFlux_70_0_instFlux
+            - base_CircularApertureFlux_70_0_instFluxErr
+    ap70Flux_flag:
+        functor: Column
+        args: base_CircularApertureFlux_70_0_flag
     # TODO: When DM-25019 is complete, these should be
     # changed to use the local value of the background
     # model, rather than the residual of the background
@@ -148,45 +249,8 @@ flags:
    - base_CircularApertureFlux_12_0_instFlux
    - base_CircularApertureFlux_12_0_instFluxErr
    - base_CircularApertureFlux_17_0_flag
-   - base_CircularApertureFlux_17_0_flag_apertureTruncated
    - base_CircularApertureFlux_17_0_instFlux
    - base_CircularApertureFlux_17_0_instFluxErr
-   - base_CircularApertureFlux_25_0_flag
-   - base_CircularApertureFlux_25_0_flag_apertureTruncated
-   - base_CircularApertureFlux_25_0_instFlux
-   - base_CircularApertureFlux_25_0_instFluxErr
-   - base_CircularApertureFlux_35_0_flag
-   - base_CircularApertureFlux_35_0_flag_apertureTruncated
-   - base_CircularApertureFlux_35_0_instFlux
-   - base_CircularApertureFlux_35_0_instFluxErr
-   - base_CircularApertureFlux_3_0_flag
-   - base_CircularApertureFlux_3_0_flag_apertureTruncated
-   - base_CircularApertureFlux_3_0_flag_sincCoeffsTruncated
-   - base_CircularApertureFlux_3_0_instFlux
-   - base_CircularApertureFlux_3_0_instFluxErr
-   - base_CircularApertureFlux_4_5_flag
-   - base_CircularApertureFlux_4_5_flag_apertureTruncated
-   - base_CircularApertureFlux_4_5_flag_sincCoeffsTruncated
-   - base_CircularApertureFlux_4_5_instFlux
-   - base_CircularApertureFlux_4_5_instFluxErr
-   - base_CircularApertureFlux_50_0_flag
-   - base_CircularApertureFlux_50_0_flag_apertureTruncated
-   - base_CircularApertureFlux_50_0_instFlux
-   - base_CircularApertureFlux_50_0_instFluxErr
-   - base_CircularApertureFlux_6_0_flag
-   - base_CircularApertureFlux_6_0_flag_apertureTruncated
-   - base_CircularApertureFlux_6_0_flag_sincCoeffsTruncated
-   - base_CircularApertureFlux_6_0_instFlux
-   - base_CircularApertureFlux_6_0_instFluxErr
-   - base_CircularApertureFlux_70_0_flag
-   - base_CircularApertureFlux_70_0_flag_apertureTruncated
-   - base_CircularApertureFlux_70_0_instFlux
-   - base_CircularApertureFlux_70_0_instFluxErr
-   - base_CircularApertureFlux_9_0_flag
-   - base_CircularApertureFlux_9_0_flag_apertureTruncated
-   - base_CircularApertureFlux_9_0_flag_sincCoeffsTruncated
-   - base_CircularApertureFlux_9_0_instFlux
-   - base_CircularApertureFlux_9_0_instFluxErr
    - base_ClassificationExtendedness_flag
    - base_FootprintArea_value
    - base_Jacobian_flag

--- a/policy/imsim/Source.yaml
+++ b/policy/imsim/Source.yaml
@@ -39,14 +39,14 @@ funcs:
     # declErr: not available yet DM-15180
     # ra_decl_Cov: not available yet
     # One calibrated Calib flux is important:
-    ApFlux:
+    apFlux:
         functor: LocalNanojansky
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    ApFluxErr:
+    apFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_CalibFlux_instFlux
@@ -70,14 +70,14 @@ funcs:
             - base_LocalBackground_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsFlux:
+    psfFlux:
         functor: LocalNanojansky
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
             - base_LocalPhotoCalibErr
-    PsFluxErr:
+    psfFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_PsfFlux_instFlux
@@ -104,23 +104,23 @@ funcs:
     # psFlux_psDecl_Cov
 
 
-    Ixx:
+    ixx:
         functor: Column
         args: slot_Shape_xx
-    Iyy:
+    iyy:
         functor: Column
         args: slot_Shape_yy
-    Ixy:
+    ixy:
         functor: Column
         args: slot_Shape_xy
     # DPDD should include Psf Shape
-    IxxPsf:
+    ixxPSF:
         functor: Column
         args: slot_PsfShape_xx
-    IyyPsf:
+    iyyPSF:
         functor: Column
         args: slot_PsfShape_yy
-    IxyPsf:
+    ixyPSF:
         functor: Column
         args: slot_PsfShape_xy
     # apNann: Replaced by raw Aperture instFluxes in flags section below
@@ -196,7 +196,6 @@ flags:
    - base_LocalBackground_flag
    - base_LocalBackground_flag_noGoodPixels
    - base_LocalBackground_flag_noPsf
-   - base_PixelFlags_flag
    - base_PixelFlags_flag_bad
    - base_PixelFlags_flag_cr
    - base_PixelFlags_flag_crCenter
@@ -256,18 +255,20 @@ flags:
 flag_rename_rules:
     # Taken from db-meas-forced
     - ['ext_photometryKron_', '']
-    - ['base_PixelFlags_flag', 'PixelFlags']
-    - ['base_Classification', '']
-    - ['base_Sdss', '']
-    - ['base_CircularApertureFlux', 'ApFlux']
-    - ['ext_shapeHSM_', '']
+    - ['base_Blendedness', 'base_blendedness']
+    - ['base_Local', 'local']
+    - ['base_PixelFlags_flag', 'pixelFlags']
+    - ['base_ClassificationE', 'e']
+    - ['base_SdssCentroid', 'centroid']
+    - ['base_Variance', 'variance']
+    - ['base_Psf', 'psf']
+    - ['base_CircularApertureFlux', 'apFlux']
+    - ['base_FootprintArea', 'footprintArea']
+    - ['base_Jacobian', 'jacobian']
+    - ['ext_shapeHSM_Hsm', 'hsm']
     - ['ext_convolved_', '']
     - ['undeblended_base', 'undeblended']
     - ['undeblended_ext_photometryKron', 'undeblended']
     - ['ext_photometryKron_', '']
     - ['base_', '']
     - ['slot_', '']
-    - ['calib_', 'Calib_']
-    - ['deblend_', 'Deblend_']
-    - ['blendedness', 'Blendedness']
-


### PR DESCRIPTION
* Added all the columns used by pipe_analysis and analysis_drp to the object table
* Added all the apertures to the aperture fluxes
*  all dataframes have primary keys as index only
* object table columns look like `g_apFlux` instead of `gApFlux`
* All per-patch datasets are consolidated into a per-tract dataset
* names start with lowercase


I promise to squash these before merging