### PR TITLE
DM-31912:  Add additional GAaP circular apertures for DP0.2

### DIFF
--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -75,7 +75,6 @@ if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
     config.measureApCorr.allowFailure += names
 
 if "ext_gaap_GaapFlux" in config.measurement.plugins:
-    config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
     names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
     config.measureApCorr.allowFailure += names
 

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -35,9 +35,6 @@ config.measurement.slots.gaussianFlux = None
 config.catalogCalculation.plugins.names = ["base_ClassificationExtendedness"]
 config.measurement.slots.psfFlux = "base_PsfFlux"
 
-# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
-config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
-
 def doUndeblended(config, algName, fluxList=None):
     """Activate undeblended measurements of algorithm
     Parameters

--- a/config/gaap.py
+++ b/config/gaap.py
@@ -22,3 +22,6 @@
 
 import lsst.meas.extensions.gaap  # noqa: Load GAaP algorithm
 config.plugins.names.add("ext_gaap_GaapFlux")
+config.plugins["ext_gaap_GaapFlux"].sigmas = [0.5, 0.7, 1.0, 1.5, 2.5, 3.0]
+# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+config.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -235,10 +235,6 @@ funcs:
         args:
             - ext_gaap_GaapFlux_1_15x_Optimal_instFlux
             - ext_gaap_GaapFlux_1_15x_Optimal_instFluxErr
-    gaapFlux_optimal_flag_bigPsf:
-        functor: Column
-        dataset: forced_src
-        args: ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
     # Taking Shape from meas
     ixx:
         functor: Column

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -148,44 +148,88 @@ funcs:
     # izStd:
     # zyStd:
     #  PSF GAaP flux
-    gaapFlux_psf:
+    gaapPsfFlux:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_PsfFlux_instFlux
-    gaapFluxErr_psf:
+    gaapPsfFluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_PsfFlux_instFlux
             - ext_gaap_GaapFlux_1_15x_PsfFlux_instFluxErr
+    # 0.5 arcsec sigma GAaP flux
+    gaap0p5Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: ext_gaap_GaapFlux_1_15x_0_5_instFlux
+    gaap0p5FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - ext_gaap_GaapFlux_1_15x_0_5_instFlux
+            - ext_gaap_GaapFlux_1_15x_0_5_instFluxErr
     # 0.7 arcsec sigma GAaP flux
-    gaapFlux_0_7:
+    gaap0p7Flux:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_0_7_instFlux
-    gaapFluxErr_0_7:
+    gaap0p7FluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_0_7_instFlux
             - ext_gaap_GaapFlux_1_15x_0_7_instFluxErr
     # 1.0 arcsec sigma GAaP flux
-    gaapFlux_1_0:
+    gaap1p0Flux:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_1_0_instFlux
-    gaapFluxErr_1_0:
+    gaap1p0FluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
             - ext_gaap_GaapFlux_1_15x_1_0_instFlux
             - ext_gaap_GaapFlux_1_15x_1_0_instFluxErr
+    # 1.5 arcsec sigma GAaP flux
+    gaap1p5Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: ext_gaap_GaapFlux_1_15x_1_5_instFlux
+    gaap1p5FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - ext_gaap_GaapFlux_1_15x_1_5_instFlux
+            - ext_gaap_GaapFlux_1_15x_1_5_instFluxErr
+    # 2.5 arcsec sigma GAaP flux
+    gaap2p5Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: ext_gaap_GaapFlux_1_15x_2_5_instFlux
+    gaap2p5FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - ext_gaap_GaapFlux_1_15x_2_5_instFlux
+            - ext_gaap_GaapFlux_1_15x_2_5_instFluxErr
+    # 3.0 arcsec sigma GAaP flux
+    gaap3p0Flux:
+        functor: NanoJansky
+        dataset: forced_src
+        args: ext_gaap_GaapFlux_1_15x_0_5_instFlux
+    gaap3p0FluxErr:
+        functor: NanoJanskyErr
+        dataset: forced_src
+        args:
+            - ext_gaap_GaapFlux_1_15x_3_0_instFlux
+            - ext_gaap_GaapFlux_1_15x_3_0_instFluxErr
     #  Optimal GAaP flux
-    gaapFlux_optimal:
+    gaapOptimalFlux:
         functor: NanoJansky
         dataset: forced_src
         args: ext_gaap_GaapFlux_1_15x_Optimal_instFlux
-    gaapFluxErr_optimal:
+    gaapOptimalFluxErr:
         functor: NanoJanskyErr
         dataset: forced_src
         args:
@@ -631,14 +675,25 @@ forcedFlags:
     - ext_gaap_GaapFlux_flag
     - ext_gaap_GaapFlux_flag_edge
     - ext_gaap_GaapFlux_1_15x_flag_gaussianization
+    - ext_gaap_GaapFlux_1_15x_Optimal_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_0_5_flag_bigPsf
     - ext_gaap_GaapFlux_1_15x_0_7_flag_bigPsf
     - ext_gaap_GaapFlux_1_15x_1_0_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_1_5_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_2_5_flag_bigPsf
+    - ext_gaap_GaapFlux_1_15x_3_0_flag_bigPsf
 flag_rename_rules:
     # Taken from db-meas-forced
     - ['modelfit_C', 'c']
     - ['base_PixelFlags_flag', 'pixelFlags']
     - ['base_CircularApertureFlux', 'apFlux']
     - ['ext_convolved_', '']
+    - ['ext_gaap_GaapFlux_1_15x_0_5', 'gaap0p5Flux']
+    - ['ext_gaap_GaapFlux_1_15x_0_7', 'gaap0p7Flux']
+    - ['ext_gaap_GaapFlux_1_15x_1_0', 'gaap1p0Flux']
+    - ['ext_gaap_GaapFlux_1_15x_1_5', 'gaap1p5Flux']
+    - ['ext_gaap_GaapFlux_1_15x_2_5', 'gaap2p5Flux']
+    - ['ext_gaap_GaapFlux_1_15x_3_0', 'gaap3p0Flux']
     - ['ext_gaap_GaapFlux_1_15x', 'gaapFlux']
     - ['ext_gaap_GaapFlux', 'gaapFlux']
     - ['undeblended_base', 'undeblended']

--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -694,6 +694,7 @@ flag_rename_rules:
     - ['ext_gaap_GaapFlux_1_15x_1_5', 'gaap1p5Flux']
     - ['ext_gaap_GaapFlux_1_15x_2_5', 'gaap2p5Flux']
     - ['ext_gaap_GaapFlux_1_15x_3_0', 'gaap3p0Flux']
+    - ['ext_gaap_GaapFlux_1_15x_Optimal', 'gaapOptimalFlux']
     - ['ext_gaap_GaapFlux_1_15x', 'gaapFlux']
     - ['ext_gaap_GaapFlux', 'gaapFlux']
     - ['undeblended_base', 'undeblended']


### PR DESCRIPTION
This PR is a duplicate of https://github.com/lsst/obs_lsst/pull/352 that @sr525 reviewed.  It required coordination with DM-31825 and here is the copy that was Jenkins'ed with DM-31825