### PR TITLE
DM-32315: Enforce setVisitInfo/setExposureId consistency in Gen 2.

### DIFF
--- a/python/lsst/obs/lsst/lsstCamMapper.py
+++ b/python/lsst/obs/lsst/lsstCamMapper.py
@@ -455,6 +455,7 @@ class LsstCamBaseMapper(CameraMapper):
 
         exp = self._standardizeExposure(self.exposures['raw'], item, dataId, trimmed=False,
                                         setVisitInfo=False,  # it's already set, and the metadata's stripped
+                                        setExposureId=False,
                                         filter=False)
 
         if filter:


### PR DESCRIPTION
This PR explicitly excludes the changes made on lsst/obs_base#395 from LSST raws (reproducing the previous effect of `setVisitInfo=False`), primarily as a guard against the `obs_base` default changing.