### PR TITLE
DM-32448-v23: Fix the column name error for gaap3p0Flux

### DIFF
--- a/policy/imsim/Object.yaml
+++ b/policy/imsim/Object.yaml
@@ -217,7 +217,7 @@ funcs:
     gaap3p0Flux:
         functor: NanoJansky
         dataset: forced_src
-        args: ext_gaap_GaapFlux_1_15x_0_5_instFlux
+        args: ext_gaap_GaapFlux_1_15x_3_0_instFlux
     gaap3p0FluxErr:
         functor: NanoJanskyErr
         dataset: forced_src


### PR DESCRIPTION
Backporting the patch that fixes an error in one of the GAaP color columns