### PR TITLE
DM-32666: Add gaussianFlux to Source Table

### DIFF
--- a/policy/imsim/Source.yaml
+++ b/policy/imsim/Source.yaml
@@ -281,6 +281,23 @@ funcs:
     # apNann: Replaced by raw Aperture instFluxes in flags section below
     # apMeanSb:  Replaced by raw Aperture instFluxes in flags section below
     # apMeanSbErr:  Replaced by raw Aperture instFluxes in flags section below
+
+    # DPDD does not include gaussianFluxes, however they are used for
+    # the single frame extendedness column which is used for QA.
+    gaussianFlux:
+        functor: LocalNanojansky
+        args:
+            - base_GaussianFlux_instFlux
+            - base_GaussianFlux_instFluxErr
+            - base_LocalPhotoCalib
+            - base_LocalPhotoCalibErr
+    gaussianFluxErr:
+        functor: LocalNanojanskyErr
+        args:
+            - base_GaussianFlux_instFlux
+            - base_GaussianFlux_instFluxErr
+            - base_LocalPhotoCalib
+            - base_LocalPhotoCalibErr
     extendedness:
         functor: Column
         args: base_ClassificationExtendedness_value
@@ -332,6 +349,7 @@ flags:
    - base_PsfFlux_flag_apCorr
    - base_PsfFlux_flag_edge
    - base_PsfFlux_flag_noGoodPixels
+   - base_GaussianFlux_flag
    - base_SdssCentroid_flag
    - base_SdssCentroid_flag_almostNoSecondDerivative
    - base_SdssCentroid_flag_badError
@@ -380,6 +398,7 @@ flag_rename_rules:
     - ['base_SdssCentroid', 'centroid']
     - ['base_Variance', 'variance']
     - ['base_Psf', 'psf']
+    - ['base_GaussianFlux', 'gaussianFlux']
     - ['base_CircularApertureFlux', 'apFlux']
     - ['base_FootprintArea', 'footprintArea']
     - ['base_Jacobian', 'jacobian']


### PR DESCRIPTION
The single frame extendedness column is used for QA.
Therefore, the fluxes from which it is computed
(gaussian and psf) also be used for QA. If a column is
needed for QA then it will also be needed during analysis.