### PR TITLE
DM-33766: Photodiode test depends on other tests having run

### DIFF
--- a/python/lsst/obs/lsst/_ingestPhotodiode.py
+++ b/python/lsst/obs/lsst/_ingestPhotodiode.py
@@ -119,7 +119,8 @@ class PhotodiodeIngestTask(Task):
         Raises
         ------
         RuntimeError :
-            Raised if multiple exposures are found for a photodiode file.
+            Raised if the number of exposures found for a photodiode
+            file is not one
         """
         files = ResourcePath.findFileResources(locations, file_filter)
 
@@ -139,6 +140,7 @@ class PhotodiodeIngestTask(Task):
 
         refs = []
         numExisting = 0
+        numFailed = 0
         for inputFile in files:
             # Convert the file into the right class.
             with inputFile.as_local() as localFile:
@@ -161,12 +163,15 @@ class PhotodiodeIngestTask(Task):
                 exposureId = exposureRecords[0].id
                 calib.updateMetadata(camera=self.camera, exposure=exposureId)
             elif nRecords == 0:
+                numFailed += 1
                 self.log.warning("Skipping instrument %s and dayObs/seqNum %d %d: no exposures found.",
                                  instrumentName, dayObs, seqNum)
                 continue
             else:
-                raise RuntimeError(f"Multiple exposure entries found for instrument {instrumentName} and "
-                                   f"dayObs/seqNum {dayObs} {seqNum}")
+                numFailed += 1
+                self.log.warning(f"Multiple exposure entries found for instrument {instrumentName} and "
+                                 f"dayObs/seqNum {dayObs} {seqNum}")
+                continue
 
             # Generate the dataId for this file.
             dataId = DataCoordinate.standardize(
@@ -208,5 +213,6 @@ class PhotodiodeIngestTask(Task):
 
         if numExisting != 0:
             self.log.warning("Skipped %d entries that already existed in run %s", numExisting, run)
-
+        if numFailed != 0:
+            raise RuntimeError(f"Failed to ingest {numFailed} entries due to missing exposure information.")
         return refs

--- a/python/lsst/obs/lsst/_ingestPhotodiode.py
+++ b/python/lsst/obs/lsst/_ingestPhotodiode.py
@@ -118,7 +118,7 @@ class PhotodiodeIngestTask(Task):
 
         Raises
         ------
-        RuntimeError :
+        RuntimeError
             Raised if the number of exposures found for a photodiode
             file is not one
         """
@@ -169,8 +169,8 @@ class PhotodiodeIngestTask(Task):
                 continue
             else:
                 numFailed += 1
-                self.log.warning(f"Multiple exposure entries found for instrument {instrumentName} and "
-                                 f"dayObs/seqNum {dayObs} {seqNum}")
+                self.log.warning("Multiple exposure entries found for instrument %s and "
+                                 "dayObs/seqNum %d %d.", instrumentName, dayObs, seqNum)
                 continue
 
             # Generate the dataId for this file.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -137,7 +137,6 @@ class LSSTCamPhotodiodeIngestTestCase(lsst.utils.tests.TestCase):
     ingestDir = TESTDIR
     file = os.path.join(DATAROOT, "lsstCam", "raw", "2021-12-12",
                         "30211212000310", "30211212000310-R22-S22-det098.fits")
-    transfer = "auto"
     dataIds = [dict(instrument="LSSTCam", exposure=3021121200310, detector=98)]
     filterLabel = lsst.afw.image.FilterLabel(physical="SDSSi", band="i")
     pdPath = os.path.join(DATAROOT, "lsstCam", "raw")
@@ -188,8 +187,6 @@ class LSSTCamPhotodiodeIngestTestCase(lsst.utils.tests.TestCase):
                 self.file,
                 "--output-run",
                 outputRun,
-                "--transfer",
-                self.transfer,
                 "--ingest-task",
                 self.rawIngestTask,
             ],

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -24,6 +24,7 @@
 
 import unittest
 import os
+import tempfile
 import lsst.utils.tests
 
 from lsst.afw.math import flipImage
@@ -130,22 +131,37 @@ class LSSTCamIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase):
     filterLabel = lsst.afw.image.FilterLabel(physical="unknown", band="unknown")
 
 
-class LSSTCamPhotodiodeIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase):
-
-    curatedCalibrationDatasetTypes = ("camera",)
+class LSSTCamPhotodiodeIngestTestCase(lsst.utils.tests.TestCase):
     instrumentClassName = "lsst.obs.lsst.LsstCam"
+    rawIngestTask = "lsst.obs.base.RawIngestTask"
     ingestDir = TESTDIR
     file = os.path.join(DATAROOT, "lsstCam", "raw", "2021-12-12",
                         "30211212000310", "30211212000310-R22-S22-det098.fits")
+    transfer = "auto"
     dataIds = [dict(instrument="LSSTCam", exposure=3021121200310, detector=98)]
     filterLabel = lsst.afw.image.FilterLabel(physical="SDSSi", band="i")
     pdPath = os.path.join(DATAROOT, "lsstCam", "raw")
 
-    def testPhotodiode(self, pdPath=None):
-        self._ingestRaws("auto")
+    def setUp(self):
+        """Setup for lightweight photodiode ingest task.
 
-        if pdPath is None:
-            pdPath = self.pdPath
+        This will create the repo and register the instrument.
+        """
+        self.root = tempfile.mkdtemp(dir=self.ingestDir)
+
+        # Create Repo
+        runner = LogCliRunner()
+        result = runner.invoke(butlerCli, ["create", self.root])
+        self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
+
+        # Register Instrument
+        runner = LogCliRunner()
+        result = runner.invoke(butlerCli, ["register-instrument", self.root, self.instrumentClassName])
+        self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
+
+    def testPhotodiodeFailure(self):
+        """Test ingest to a repo missing exposure information will raise.
+        """
         runner = LogCliRunner()
         result = runner.invoke(
             butlerCli,
@@ -153,11 +169,48 @@ class LSSTCamPhotodiodeIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase)
                 "ingest-photodiode",
                 self.root,
                 self.instrumentClassName,
-                pdPath,
+                self.pdPath,
+            ],
+        )
+        self.assertEqual(result.exit_code, 1, f"output: {result.output} exception: {result.exception}")
+
+    def testPhotodiode(self):
+        """Test ingest to a repo with the exposure information will not raise.
+        """
+        # Ingest raw to provide exposure information.
+        outputRun = "raw_ingest_" + self.id()
+        runner = LogCliRunner()
+        result = runner.invoke(
+            butlerCli,
+            [
+                "ingest-raws",
+                self.root,
+                self.file,
+                "--output-run",
+                outputRun,
+                "--transfer",
+                self.transfer,
+                "--ingest-task",
+                self.rawIngestTask,
             ],
         )
         self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
 
+        # Ingest photodiode matching this exposure.
+        runner = LogCliRunner()
+        result = runner.invoke(
+            butlerCli,
+            [
+                "ingest-photodiode",
+                self.root,
+                self.instrumentClassName,
+                self.pdPath,
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
+
+        # Confirm that we can retrieve the ingested photodiode, and
+        # that it has the correct type.
         butler = Butler(self.root, run="LSSTCam/calib/photodiode")
         getResult = butler.get('photodiode', dataId=self.dataIds[0])
         self.assertIsInstance(getResult, PhotodiodeCalib)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -142,6 +142,8 @@ class LSSTCamPhotodiodeIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase)
     pdPath = os.path.join(DATAROOT, "lsstCam", "raw")
 
     def testPhotodiode(self, pdPath=None):
+        self._ingestRaws("auto")
+
         if pdPath is None:
             pdPath = self.pdPath
         runner = LogCliRunner()


### PR DESCRIPTION
I've added a call to `ingestRaws` to the photodiode test.  As all tests ingest to a unique collection, this should be a safe way to ensure that the needed exposure information exists.