### PR TITLE
DM-34989: Update obs_lsst to fix common problems.

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -28,3 +28,4 @@ config.doDefect = False
 config.doCrosstalk = True
 config.qa.doThumbnailOss = False
 config.qa.doThumbnailFlattened = False
+config.overscan.fitType = "MEDIAN_PER_ROW"

--- a/config/latiss/isr.py
+++ b/config/latiss/isr.py
@@ -24,3 +24,4 @@ latiss-specific overrides for IsrTask
 """
 config.doCrosstalk=False
 config.doDefect=True
+config.overscan.fitType="MEDIAN_PER_ROW"

--- a/policy/cameraHeader.yaml
+++ b/policy/cameraHeader.yaml
@@ -68,11 +68,11 @@ AMP_ITL : &AMP_ITL
     readCorner : LL
 
     #                         [[x0,  y0], [xsize, ysize]]
-    rawBBox                 : [[0,    0], [544,    2048]]  # total size of one amp's raw data
+    rawBBox                 : [[0,    0], [576,    2048]]  # total size of one amp's raw data
 
     rawDataBBox             : [[3,    0], [509,    2000]]  # data region in raw data
     rawSerialPrescanBBox    : [[0,    0], [3,      2000]]  # serial prescan (often == extended)
-    rawSerialOverscanBBox   : [[512,  0], [32,     2000]]  # serial overscan
+    rawSerialOverscanBBox   : [[512,  0], [64,     2000]]  # serial overscan
     rawParallelPrescanBBox  : [[0,    1], [0,         0]]  # pixels digitised before first parallel transfer
     rawParallelOverscanBBox : [[3, 2000], [509,      48]]  # parallel overscan
 

--- a/python/lsst/obs/lsst/assembly.py
+++ b/python/lsst/obs/lsst/assembly.py
@@ -168,8 +168,14 @@ def fixAmpGeometry(inAmp, bbox, metadata, logCmd=None):
     datasec = bboxFromIraf(d["DATASEC"]) if "DATASEC" in d else None
     biassec = bboxFromIraf(d["BIASSEC"]) if "BIASSEC" in d else None
 
-    if detsec and outAmp.getBBox() != detsec:
-        logCmd("DETSEC doesn't match (%s != %s)", outAmp.getBBox(), detsec)
+    # 2022-11-11: There is a known issue that the header DETSEC have
+    # the y-axis values flipped between the C0x and C1x entries.  This
+    # is incorrect, and disagrees with the cameraGeom values.
+    # DM-36115 contains additional details.  This test has been
+    # disabled to remove useless warnings until that is resolved.
+    # if detsec and outAmp.getBBox() != detsec:
+    #    logCmd("DETSEC doesn't match (%s != %s)",
+    #           outAmp.getBBox(), detsec)
     if datasec and outAmp.getRawDataBBox() != datasec:
         logCmd("DATASEC doesn't match for (%s != %s)", outAmp.getRawDataBBox(), detsec)
     if biassec and outAmp.getRawHorizontalOverscanBBox() != biassec:


### PR DESCRIPTION
* Set size of ITL overscan region to 64 pixels.
* Remove DETSEC log warning that will always trigger due to external value mismatches.
* Set the overscan.fitType default to MEDIAN_PER_ROW.