### PR TITLE
DM-36390: calibrations should track sequencer crc

### DIFF
--- a/config/latiss/isr.py
+++ b/config/latiss/isr.py
@@ -26,4 +26,4 @@ config.doCrosstalk=False
 config.doDefect=True
 config.overscan.fitType="MEDIAN_PER_ROW"
 config.overscan.doParallelOverscan=True
-config.cameraKeywords=["SEQNAME", "SEQFILE", "SEQCKSUM", "ODP", "AP0_RC"]
+config.cameraKeywordsToCompare=["SEQNAME", "SEQFILE", "SEQCKSUM", "ODP", "AP0_RC"]

--- a/config/latiss/isr.py
+++ b/config/latiss/isr.py
@@ -26,3 +26,4 @@ config.doCrosstalk=False
 config.doDefect=True
 config.overscan.fitType="MEDIAN_PER_ROW"
 config.overscan.doParallelOverscan=True
+config.cameraKeywords=["SEQNAME", "SEQFILE", "SEQCKSUM", "ODP", "AP0_RC"]


### PR DESCRIPTION
Add keywords to check for LATISS exposure/calib matching.