### PR TITLE
DM-38005: Update astrometry reference matcher configs for LATISS

### DIFF
--- a/config/latiss/calibrate.py
+++ b/config/latiss/calibrate.py
@@ -7,22 +7,29 @@ config.photoCal.match.referenceSelection.magLimit.fluxField = "r_flux"
 # We often have very few sources due to smaller aperture so use affine task. 
 config.astrometry.wcsFitter.retarget(FitAffineWcsTask)
 
-# Increase maxoffset as AUXTEL pointing can be unreliable. Between Feb2020-Mar2022 we saw offsets
-# of up to 4 arcmin, which translates to 2400pix. We choose 3000 as a conservative limit. pixelMargin 
-# also increased to ensure refcat overlap when we see large pointing offsets considering a 3000pix 
-# offset and detector half-width of 2100pix. 
-config.astromRefObjLoader.pixelMargin = 900
-config.astrometry.matcher.maxOffsetPix = 3000
+# Note that the following two config values were validated on data taken in
+# 2022-11 and 2022-12, which is after some major improvements were made to
+# the pointing accuracy of AuxTel. The improvements came from updates made
+# in 2022-05 (with further improvements throughout the year). As such, these
+# configs are likely only appropriate for data starting from 2022-05. If
+# processing earlier data, these may need to be relaxed to the previous values
+# (pixelMargin = 900 & maxOffsetPix = 3000) to avoid astrometric fit failures.
+config.astromRefObjLoader.pixelMargin = 250
+config.astrometry.matcher.maxOffsetPix = 900
 
 # Apply a magnitude limit and decrease the SNR limit as we're only a 1.2m
-# and frequently take short exposures. Also, allow max rotation while the
-# instrumental repeatability isn't good.
+# and frequently take short exposures.
 config.astrometry.referenceSelector.doMagLimit = True
-config.astrometry.referenceSelector.magLimit.minimum = 1
+config.astrometry.referenceSelector.magLimit.minimum = 8
 config.astrometry.referenceSelector.magLimit.maximum = 18
 config.astrometry.referenceSelector.magLimit.fluxField = "phot_g_mean_flux"
-config.astrometry.matcher.maxRotationDeg = 5.99
+config.astrometry.matcher.maxRotationDeg = 2.0
+
 config.astrometry.sourceSelector['matcher'].minSnr = 10
+
+# Turn on reference vs. source magnitude outlier rejection to help avoid bad
+# matches.
+config.astrometry.doMagnitudeOutlierRejection = True
 
 # Write srcMatchFull
 config.doWriteMatchesDenormalized = True


### PR DESCRIPTION
Now that the pointing accruacy and stability has improved for AutTel, the bbox padding for reference catalog loading can be greatly reduced. This has the benefit of avoiding many very bad fits where the matcher locked onto sources way outside of the true field for the exposure.