### PR TITLE
DM-38520: Optimize raw header reading

### DIFF
--- a/python/lsst/obs/lsst/assembly.py
+++ b/python/lsst/obs/lsst/assembly.py
@@ -163,10 +163,9 @@ def fixAmpGeometry(inAmp, bbox, metadata, logCmd=None):
     #
     # Only warn about the first amp, use debug for the others
     #
-    d = metadata.toDict()
-    detsec = bboxFromIraf(d["DETSEC"]) if "DETSEC" in d else None
-    datasec = bboxFromIraf(d["DATASEC"]) if "DATASEC" in d else None
-    biassec = bboxFromIraf(d["BIASSEC"]) if "BIASSEC" in d else None
+    detsec = bboxFromIraf(metadata["DETSEC"]) if "DETSEC" in metadata else None
+    datasec = bboxFromIraf(metadata["DATASEC"]) if "DATASEC" in metadata else None
+    biassec = bboxFromIraf(metadata["BIASSEC"]) if "BIASSEC" in metadata else None
 
     # 2022-11-11: There is a known issue that the header DETSEC have
     # the y-axis values flipped between the C0x and C1x entries.  This

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -56,13 +56,12 @@ class LsstCamRawFormatter(FitsRawFormatterBase):
     _instrument = LsstCam
 
     # These named HDUs' headers will be checked for and added to metadata.
-    _extraFitsHeaders = ["REB_COND", "CONFIG_COND"]
+    _extraFitsHeaders = ["REB_COND"]
 
     def readMetadata(self):
         """Read all header metadata directly into a PropertyList.
 
-        Specialist version since some of our data does not
-        set INHERIT=T so we have to merge the headers manually.
+        Will merge additional headers if required.
 
         Returns
         -------
@@ -71,21 +70,23 @@ class LsstCamRawFormatter(FitsRawFormatterBase):
         """
         file = self.fileDescriptor.location.path
 
-        # For LSSTCam-style data we only want the primary header and
-        # do not read the per-amp headers.
-        base_md = lsst.afw.fits.readMetadata(file, 0)
+        with lsst.afw.fits.Fits(file, "r") as hdu:
+            hdu.setHdu(0)
+            base_md = hdu.readMetadata()
 
-        ehdrs = []
-        for hduname in self._extraFitsHeaders:
-            try:
-                ehdr = lsst.afw.fits.readMetadata(file, hduname)
-            except lsst.afw.fits.FitsError:
-                # We can ignore this, the header doesn't exist in this file.
-                continue
-            else:
-                ehdrs.append(ehdr)
+            # Any extra HDUs we need to read.
+            ehdrs = []
+            for hduname in self._extraFitsHeaders:
+                try:
+                    hdu.setHdu(hduname)
+                    ehdr = hdu.readMetadata()
+                except lsst.afw.fits.FitsError:
+                    # The header doesn't exist in this file. Skip.
+                    continue
+                else:
+                    ehdrs.append(ehdr)
 
-        final_md = merge_headers([base_md] + ehdrs, mode="first")
+        final_md = merge_headers([base_md] + ehdrs, mode="overwrite")
         fix_header(final_md, translator_class=self.translatorClass)
         return final_md
 

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -86,7 +86,7 @@ class LsstCamRawFormatter(FitsRawFormatterBase):
                 ehdrs.append(ehdr)
 
         final_md = merge_headers([base_md] + ehdrs, mode="first")
-        fix_header(final_md)
+        fix_header(final_md, translator_class=self.translatorClass)
         return final_md
 
     def stripMetadata(self):

--- a/python/lsst/obs/lsst/rawFormatter.py
+++ b/python/lsst/obs/lsst/rawFormatter.py
@@ -231,6 +231,7 @@ class LsstCamPhoSimRawFormatter(LsstCamRawFormatter):
     translatorClass = LsstCamPhoSimTranslator
     _instrument = LsstCamPhoSim
     filterDefinitions = LsstCamPhoSim.filterDefinitions
+    _extraFitsHeaders = [1]
 
 
 class LsstTS8RawFormatter(LsstCamRawFormatter):


### PR DESCRIPTION
Reading the raw header was slow. This PR seems to make things 3x faster.

* No longer read CONFIG_COND HDU
* No longer read the first amplifier header.
* No longer try to strip WCS headers (which takes a long time because it has to try to create a WCS) if there is no CRPIX key present.
* Change merge scheme to use "overwrite" instead of "first" since overwriting is much faster.
* Specify the translator class when fixing header (this should have been done all along).