### PR TITLE
DM-39327: added config files for analysis_tools associatedSourcesTractAnalysis

### DIFF
--- a/config/latiss/associatedSourcesTractAnalysis.py
+++ b/config/latiss/associatedSourcesTractAnalysis.py
@@ -1,0 +1,7 @@
+import os.path
+from lsst.pipe.tasks.postprocess import TransformObjectCatalogConfig
+
+# By default loop over all the same bands that are present in the Object Table
+objectConfig = TransformObjectCatalogConfig()
+objectConfig.load(os.path.join(os.path.dirname(__file__), "transformObjectCatalog.py"))
+config.bands = objectConfig.outputBands

--- a/config/latiss/transformObjectCatalog.py
+++ b/config/latiss/transformObjectCatalog.py
@@ -1,0 +1,3 @@
+# Always produce these output bands in the Parquet coadd tables, no matter
+# what bands are in the input.
+config.outputBands = ["g", "r", "i"]


### PR DESCRIPTION
This adds the two config files needed to run photometric repeatability focal plane plots. 