### PR TITLE
DM-39505: Enable crosstalk correction for LATISS

### DIFF
--- a/config/latiss/isr.py
+++ b/config/latiss/isr.py
@@ -22,7 +22,7 @@
 """
 latiss-specific overrides for IsrTask
 """
-config.doCrosstalk=False
+config.doCrosstalk=True
 config.doDefect=True
 config.overscan.fitType="MEDIAN_PER_ROW"
 config.overscan.doParallelOverscan=True


### PR DESCRIPTION
Enable crosstalk for LATISS.