### PR TITLE
DM-35579: Remove pipelines forwarding stubs.

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,4 +10,4 @@ jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/yamllint.yaml@main
     with:
-      args: "corrections tests pipelines"
+      args: "corrections tests"

--- a/pipelines/imsim/DRP.yaml
+++ b/pipelines/imsim/DRP.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/ingredients/LSSTCam-imSim/DRP.yaml


### PR DESCRIPTION
Pipelines should go in *_pipe packages.