### PR TITLE
DM-40301: Update configurations to use large 35 pixel aperture for LATISS calibration.

### DIFF
--- a/config/latiss/calibrate.py
+++ b/config/latiss/calibrate.py
@@ -42,3 +42,7 @@ config.astrometry.doMagnitudeOutlierRejection = True
 config.doWriteMatchesDenormalized = True
 
 config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
+
+# Set the default aperture as appropriate for the LATISS plate scale.
+config.measurement.slots.apFlux='base_CircularApertureFlux_35_0'
+config.measurement.slots.calibFlux='base_CircularApertureFlux_35_0'

--- a/config/latiss/characterizeImage.py
+++ b/config/latiss/characterizeImage.py
@@ -20,7 +20,7 @@ config.measurePsf.reserve.fraction = 0.0
 config.measurePsf.psfDeterminer["psfex"].spatialOrder = 1
 
 config.installSimplePsf.width = 21
-config.installSimplePsf.fwhm = 2.355*2  # LATISS platescale is 2x LSST nominal
+config.installSimplePsf.fwhm = 2.355*2  # LATISS plate scale is 2x LSST nominal
 
 # Turn off S/N cut for aperture correction measurement source selection
 # (it now only includes calib_psf_used objects, and that cut is "good
@@ -28,3 +28,7 @@ config.installSimplePsf.fwhm = 2.355*2  # LATISS platescale is 2x LSST nominal
 config.measureApCorr.sourceSelector["science"].doSignalToNoise = False
 
 config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
+
+# Set the default aperture as appropriate for the LATISS plate scale.
+config.measurement.slots.apFlux='base_CircularApertureFlux_35_0'
+config.measurement.slots.calibFlux='base_CircularApertureFlux_35_0'

--- a/config/latiss/isolatedStarAssociation.py
+++ b/config/latiss/isolatedStarAssociation.py
@@ -1,0 +1,27 @@
+# Override calibration apertures as appropriate for LATISS plate scale.
+config.inst_flux_field='apFlux_35_0_instFlux'
+
+config.extra_columns = [
+    'x',
+    'y',
+    'apFlux_50_0_instFlux',
+    'apFlux_50_0_instFluxErr',
+    'apFlux_50_0_flag',
+    'localBackground_instFlux',
+    'localBackground_flag',
+]
+
+config.source_selector['science'].flags.bad = [
+    'pixelFlags_edge',
+    'pixelFlags_interpolatedCenter',
+    'pixelFlags_saturatedCenter',
+    'pixelFlags_crCenter',
+    'pixelFlags_bad',
+    'pixelFlags_interpolated',
+    'pixelFlags_saturated',
+    'centroid_flag',
+    'apFlux_35_0_flag',
+]
+
+config.source_selector['science'].signalToNoise.fluxField = 'apFlux_35_0_instFlux'
+config.source_selector['science'].signalToNoise.errField = 'apFlux_35_0_instFluxErr'


### PR DESCRIPTION
The default 12 pixel aperture is much too small for the LATISS platescale.