### PR TITLE
DM-40426: Add new LATISS filters collimator and cyl_lens, and new gratings holo4_001 and pinhole mask options. 

### DIFF
--- a/python/lsst/obs/lsst/filters.py
+++ b/python/lsst/obs/lsst/filters.py
@@ -298,7 +298,8 @@ _latiss_filters = (
 )
 
 # Form a new set of filter definitions from all the explicit gratings
-_latiss_gratings = ("ronchi90lpmm", "ronchi170lpmm", "empty", "unknown", "holo4_003", "blue300lpmm_qn1")
+_latiss_gratings = ("ronchi90lpmm", "ronchi170lpmm", "empty", "unknown",
+                    "holo4_003", "blue300lpmm_qn1", "holo4_001")
 
 # Include the filters without the grating in case someone wants
 # to retrieve a filter by an actual filter name

--- a/python/lsst/obs/lsst/filters.py
+++ b/python/lsst/obs/lsst/filters.py
@@ -298,8 +298,34 @@ _latiss_filters = (
 )
 
 # Form a new set of filter definitions from all the explicit gratings
-_latiss_gratings = ("ronchi90lpmm", "ronchi170lpmm", "empty", "unknown",
-                    "holo4_003", "blue300lpmm_qn1", "holo4_001")
+_latiss_gratings = ("ronchi90lpmm",
+                    "ronchi170lpmm",
+                    "empty",
+                    "unknown",
+                    "holo4_003",
+                    "blue300lpmm_qn1",
+                    "holo4_001",
+                    "pinhole_1_1000",
+                    "pinhole_1_0500",
+                    "pinhole_1_0200",
+                    "pinhole_1_0100",
+                    "pinhole_2_1_1000",
+                    "pinhole_2_1_0500",
+                    "pinhole_2_1_0200",
+                    "pinhole_2_1_0100",
+                    "pinhole_2_2_1000",
+                    "pinhole_2_2_0500",
+                    "pinhole_2_2_0200",
+                    "pinhole_2_2_0100",
+                    "pinhole_2_3_1000",
+                    "pinhole_2_3_0500",
+                    "pinhole_2_3_0200",
+                    "pinhole_2_3_0100",
+                    "pinhole_2_4_1000",
+                    "pinhole_2_4_0500",
+                    "pinhole_2_4_0200",
+                    "pinhole_2_4_0100",
+                    )
 
 # Include the filters without the grating in case someone wants
 # to retrieve a filter by an actual filter name

--- a/python/lsst/obs/lsst/filters.py
+++ b/python/lsst/obs/lsst/filters.py
@@ -291,6 +291,10 @@ _latiss_filters = (
                      band="z"),
     FilterDefinition(physical_filter="SDSSy_65mm",
                      band="y"),
+    FilterDefinition(physical_filter="collimator",
+                     band="white"),
+    FilterDefinition(physical_filter="cyl_lens",
+                     band="white"),
 )
 
 # Form a new set of filter definitions from all the explicit gratings


### PR DESCRIPTION
Jenkins run -> https://rubin-ci.slac.stanford.edu/job/stack-os-matrix/36/

Note that the PR is organized in 3 separate commits, one for the new filters, one for the new grating, and the third is for the options of the pinhole masks. The pinhole masks (there are two) will only be installed in the grating wheel, but they have configurable options as far as the aperture size and aperture locations. The names were chosen to express all available configurations as it is unknown ahead of time which aperture size/location configuration will be used. 