### PR TITLE
DM-37727-fix: Add imsim specific overrides

### DIFF
--- a/config/imsim/analysisToolsAstrometricCatalogMatch.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatch.py
@@ -1,0 +1,24 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
+config.connections.refCat = "cal_ref_cat_2_2"

--- a/config/imsim/analysisToolsAstrometricCatalogMatch.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatch.py
@@ -22,3 +22,4 @@
 
 config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
 config.connections.refCat = "cal_ref_cat_2_2"
+config.referenceCatalogLoader.refObjLoader.requireProperMotion = False

--- a/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
@@ -1,0 +1,24 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
+config.connections.refCat = "cal_ref_cat_2_2"

--- a/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
@@ -22,3 +22,4 @@
 
 config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
 config.connections.refCat = "cal_ref_cat_2_2"
+config.referenceCatalogLoader.refObjLoader.requireProperMotion = False

--- a/config/imsim/analysisToolsPhotometricCatalogMatch.py
+++ b/config/imsim/analysisToolsPhotometricCatalogMatch.py
@@ -1,0 +1,5 @@
+import os.path
+configDir = os.path.dirname(__file__)
+config.referenceCatalogLoader.refObjLoader.load(os.path.join(configDir, 'filterMap.py'))
+
+config.referenceCatalogLoader.doApplyColorTerms = False

--- a/config/imsim/analysisToolsPhotometricCatalogMatchVisit.py
+++ b/config/imsim/analysisToolsPhotometricCatalogMatchVisit.py
@@ -1,0 +1,5 @@
+import os.path
+configDir = os.path.dirname(__file__)
+config.referenceCatalogLoader.refObjLoader.load(os.path.join(configDir, 'filterMap.py'))
+
+config.referenceCatalogLoader.doApplyColorTerms = False


### PR DESCRIPTION
for analysis tools photometric matching tasks, because no colorterms apply. Pair coded hotfix with Sophie.