### PR TITLE
DM-42154: Add config overrides for LATISS multiband to turn off refcat matching.

### DIFF
--- a/config/latiss/measureCoaddSources.py
+++ b/config/latiss/measureCoaddSources.py
@@ -32,4 +32,5 @@ config.load(os.path.join(os.path.dirname(__file__), "..", "cmodel.py"))
 
 config.connections.refCat = "atlas_refcat2_20220201"
 
-config.doWriteMatchesDenormalized = True
+config.doMatchSources = False
+config.doWriteMatchesDenormalized = False

--- a/config/latiss/measureCoaddSources.py
+++ b/config/latiss/measureCoaddSources.py
@@ -29,6 +29,7 @@ config.measurement.load(os.path.join(os.path.dirname(__file__), "..", "kron.py")
 config.measurement.load(os.path.join(os.path.dirname(__file__), "..", "convolvedFluxes.py"))
 config.measurement.load(os.path.join(os.path.dirname(__file__), "..", "hsm.py"))
 config.load(os.path.join(os.path.dirname(__file__), "..", "cmodel.py"))
+config.match.refObjLoader.load(os.path.join(os.path.dirname(__file__), "filterMap.py"))
 
 config.connections.refCat = "atlas_refcat2_20220201"
 


### PR DESCRIPTION
On this PR I also added in the correct override of the filter map to allow matches to be turned on if we need them (though I don't think they're actually used anywhere).