### PR TITLE
DM-43194-fix: Add doBrighterFatter override to isr

### DIFF
--- a/config/comCamSim/isr.py
+++ b/config/comCamSim/isr.py
@@ -23,6 +23,7 @@
 comCamSim-specific overrides for IsrTask
 """
 config.doDefect = False
+config.doBrighterFatter = True
 config.connections.newBFKernel = "bfk"
 config.doCrosstalk = False
 config.doFringe = False


### PR DESCRIPTION
100% my fault for not checking together earlier. The default is False and so the the doBrighterFatter=False that was there earlier was doing nothing. 