### PR TITLE
DM-43347: Configure visit-level refcat match analysis tools  tasks for ComCamSim 

### DIFF
--- a/config/comCamSim/analysisToolsPhotometricCatalogMatchVisit.py
+++ b/config/comCamSim/analysisToolsPhotometricCatalogMatchVisit.py
@@ -4,4 +4,5 @@ import os.path
 configDir = os.path.dirname(__file__)
 config.referenceCatalogLoader.refObjLoader.load(os.path.join(configDir, 'filterMap.py'))
 
+config.connections.refCatalog = "uw_stars_20240228"
 config.referenceCatalogLoader.doApplyColorTerms = False

--- a/config/comCamSim/refCatSourceAnalysisTask.py
+++ b/config/comCamSim/refCatSourceAnalysisTask.py
@@ -1,4 +1,3 @@
 """comCamSim-specific overrides for RefCatSourceAnalysisTask"""
 
-config.connections.refCatalog = "uw_stars_20240228"
-config.connections.outputName = "sourceTable_visit_uw_stars_20240228_match"
+config.connections.data = "sourceTable_visit_uw_stars_20240228_match"

--- a/config/comCamSim/refCatSourcePhotometricAnalysisTask.py
+++ b/config/comCamSim/refCatSourcePhotometricAnalysisTask.py
@@ -1,0 +1,3 @@
+"""comCamSim-specific overrides for RefCatSourcePhotometricAnalysisTask"""
+
+config.connections.data = "sourceTable_visit_uw_stars_20240228_photoMatch"


### PR DESCRIPTION
The  RefCatSourcePhotometricAnalysisTask one, as of now is necessary, but not sufficient. 