### PR TITLE
DM-42747: Fiducial values for summary stats for comCamSim

### DIFF
--- a/config/comCamSim/calibrate.py
+++ b/config/comCamSim/calibrate.py
@@ -49,3 +49,6 @@ config.photoCal.match.referenceSelection.doMagLimit = True
 config.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_r_flux"
 config.photoCal.match.referenceSelection.magLimit.minimum = 14.0
 config.photoCal.match.referenceSelection.magLimit.maximum = 22.0
+
+# Exposure summary stats
+config.computeSummaryStats.load(os.path.join(configDir, "computeExposureSummaryStats.py"))

--- a/config/comCamSim/calibrateImage.py
+++ b/config/comCamSim/calibrateImage.py
@@ -28,3 +28,6 @@ config.photometry.match.referenceSelection.doMagLimit = True
 config.photometry.match.referenceSelection.magLimit.fluxField = "lsst_r_flux"
 config.photometry.match.referenceSelection.magLimit.minimum = 14.0
 config.photometry.match.referenceSelection.magLimit.maximum = 22.0
+
+# Exposure summary stats
+config.compute_summary_stats.load(os.path.join(config_dir, "computeExposureSummaryStats.py"))

--- a/config/comCamSim/computeExposureSummaryStats.py
+++ b/config/comCamSim/computeExposureSummaryStats.py
@@ -1,0 +1,26 @@
+import os.path
+
+config_dir = os.path.dirname(__file__)
+
+# Fiducial values come from a set of 4334 visits generated in:
+# repo='/repo/ops-rehearsal-3-prep'
+# collection='u/homer/w_2024_10/DM-43228'
+# Plots, including the median values used here, can be found on JIRA ticket DM-42747
+
+config.fiducialPsfSigma = {
+    'g': 1.72,
+    'r': 1.60,
+    'i': 1.57,
+}    
+
+config.fiducialSkyBackground = {
+    'g': 9.34,
+    'r': 19.58,
+    'i': 35.97,
+}
+
+config.fiducialZeroPoint = {
+    'g': 27.68,
+    'r': 27.56,
+    'i': 27.40,
+}

--- a/config/comCamSim/updateVisitSummary.py
+++ b/config/comCamSim/updateVisitSummary.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import os.path
+
+ObsConfigDir = os.path.dirname(__file__)
+
+config.compute_summary_stats.load(os.path.join(ObsConfigDir, "computeExposureSummaryStats.py"))


### PR DESCRIPTION
Adds fiducial values of seeing, sky brightness, and zeropoints for comCamSim in preparation for processing of Ops Rehearsal 3. Note: fiducials are not set for the `characterizeImage` task, since there is no comCamSim-specific config for this task.