### PR TITLE
DM-43576: ComCamSim config overrides for CalibrateImage cannot be applied

### DIFF
--- a/config/comCamSim/calibrateImage.py
+++ b/config/comCamSim/calibrateImage.py
@@ -30,4 +30,4 @@ config.photometry.match.referenceSelection.magLimit.minimum = 14.0
 config.photometry.match.referenceSelection.magLimit.maximum = 22.0
 
 # Exposure summary stats
-config.compute_summary_stats.load(os.path.join(config_dir, "computeExposureSummaryStats.py"))
+config.compute_summary_stats.load(os.path.join(configDir, "computeExposureSummaryStats.py"))


### PR DESCRIPTION
This PR fixes an incorrectly named variable in the CalibrateImage config.