### PR TITLE
DM-38632: Update LATISS and ComCamSim configurations for compensated tophat calibration fluxes.

### DIFF
--- a/config/comCamSim/fgcmBuildFromIsolatedStars.py
+++ b/config/comCamSim/fgcmBuildFromIsolatedStars.py
@@ -16,8 +16,6 @@ config.connections.ref_cat = "uw_stars_20240524"
 
 configDir = os.path.join(os.path.dirname(__file__))
 config.physicalFilterMap = physical_to_band
-config.doSubtractLocalBackground = True
-config.sourceSelector["science"].flags.bad.append("localBackground_flag")
 config.fgcmLoadReferenceCatalog.filterMap = {
     "g": "lsst_g",
     "r": "lsst_r",

--- a/config/latiss/calibrate.py
+++ b/config/latiss/calibrate.py
@@ -50,5 +50,8 @@ config.astrometry.sourceSelector['matcher'].minSnr = 10
 config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
 
 # Set the default aperture as appropriate for the LATISS plate scale.
+config.measurement.algorithms["base_CompensatedTophatFlux"].apertures = [35]
+config.normalizedCalibrationFlux.raw_calibflux_name = "base_CompensatedTophatFlux_35"
+
 config.measurement.slots.apFlux='base_CircularApertureFlux_35_0'
 config.measurement.slots.calibFlux='base_CircularApertureFlux_35_0'

--- a/config/latiss/characterizeImage.py
+++ b/config/latiss/characterizeImage.py
@@ -33,5 +33,7 @@ config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
 config.measurement.algorithms["base_CompensatedTophatFlux"].apertures = [35]
 config.normalizedCalibrationFlux.raw_calibflux_name = "base_CompensatedTophatFlux_35"
 config.normalizedCalibrationFlux.measure_ap_corr.refFluxName = "base_CircularApertureFlux_35_0"
+config.normalizedCalibrationFlux.measure_ap_corr.sourceSelector["science"].signalToNoise.fluxField = "base_CompensatedTophatFlux_35_instFlux"
+config.normalizedCalibrationFlux.measure_ap_corr.sourceSelector["science"].signalToNoise.errField = "base_CompensatedTophatFlux_35_instFluxErr"
 config.measurement.slots.apFlux = "base_CircularApertureFlux_35_0"
 config.measurement.slots.calibFlux = "base_CircularApertureFlux_35_0"

--- a/config/latiss/characterizeImage.py
+++ b/config/latiss/characterizeImage.py
@@ -30,5 +30,8 @@ config.measureApCorr.sourceSelector["science"].doSignalToNoise = False
 config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
 
 # Set the default aperture as appropriate for the LATISS plate scale.
-config.measurement.slots.apFlux='base_CircularApertureFlux_35_0'
-config.measurement.slots.calibFlux='base_CircularApertureFlux_35_0'
+config.measurement.algorithms["base_CompensatedTophatFlux"].apertures = [35]
+config.normalizedCalibrationFlux.raw_calibflux_name = "base_CompensatedTophatFlux_35"
+config.normalizedCalibrationFlux.measure_ap_corr.refFluxName = "base_CircularApertureFlux_35_0"
+config.measurement.slots.apFlux = "base_CircularApertureFlux_35_0"
+config.measurement.slots.calibFlux = "base_CircularApertureFlux_35_0"

--- a/config/latiss/characterizeImage.py
+++ b/config/latiss/characterizeImage.py
@@ -33,6 +33,9 @@ config.measurement.plugins["base_Jacobian"].pixelScale = 0.1
 config.measurement.algorithms["base_CompensatedTophatFlux"].apertures = [35]
 config.normalizedCalibrationFlux.raw_calibflux_name = "base_CompensatedTophatFlux_35"
 config.normalizedCalibrationFlux.measure_ap_corr.refFluxName = "base_CircularApertureFlux_35_0"
+# As above, turn off S/N cut for aperture correction source selection.
+config.normalizedCalibrationFlux.measure_ap_corr.sourceSelector["science"].doSignalToNoise = False
+# Put in the correct override fields in case we revisit this in the future.
 config.normalizedCalibrationFlux.measure_ap_corr.sourceSelector["science"].signalToNoise.fluxField = "base_CompensatedTophatFlux_35_instFlux"
 config.normalizedCalibrationFlux.measure_ap_corr.sourceSelector["science"].signalToNoise.errField = "base_CompensatedTophatFlux_35_instFluxErr"
 config.measurement.slots.apFlux = "base_CircularApertureFlux_35_0"

--- a/config/latiss/fgcmBuildFromIsolatedStars.py
+++ b/config/latiss/fgcmBuildFromIsolatedStars.py
@@ -10,18 +10,12 @@ config.coarseNside = 64
 config.minPerBand = 2
 config.connections.ref_cat = "atlas_refcat2_20220201"
 
-config.instFluxField="apFlux_35_0_instFlux"
-config.sourceSelector["science"].signalToNoise.fluxField="apFlux_35_0_instFlux"
-
-config.sourceSelector["science"].signalToNoise.errField="apFlux_35_0_instFluxErr"
-
 config.apertureInnerInstFluxField="apFlux_35_0_instFlux"
 config.apertureOuterInstFluxField="apFlux_50_0_instFlux"
 
 configDir = os.path.join(os.path.dirname(__file__))
 config.physicalFilterMap = LATISS_FILTER_DEFINITIONS.physical_to_band
-config.doSubtractLocalBackground = True
-config.sourceSelector["science"].flags.bad.append("localBackground_flag")
+config.doSubtractLocalBackground = False
 config.fgcmLoadReferenceCatalog.load(os.path.join(configDir, "filterMap.py"))
 config.fgcmLoadReferenceCatalog.applyColorTerms = True
 config.fgcmLoadReferenceCatalog.colorterms.load(os.path.join(configDir, 'colorterms.py'))

--- a/config/latiss/isolatedStarAssociation.py
+++ b/config/latiss/isolatedStarAssociation.py
@@ -1,27 +1,18 @@
 # Override calibration apertures as appropriate for LATISS plate scale.
-config.inst_flux_field='apFlux_35_0_instFlux'
-
 config.extra_columns = [
     'x',
     'y',
+    'xErr',
+    'yErr',
+    'apFlux_35_0_instFlux',
+    'apFlux_35_0_instFluxErr',
+    'apFlux_35_0_flag',
     'apFlux_50_0_instFlux',
     'apFlux_50_0_instFluxErr',
     'apFlux_50_0_flag',
     'localBackground_instFlux',
     'localBackground_flag',
+    'ixx',
+    'iyy',
+    'ixy',
 ]
-
-config.source_selector['science'].flags.bad = [
-    'pixelFlags_edge',
-    'pixelFlags_interpolatedCenter',
-    'pixelFlags_saturatedCenter',
-    'pixelFlags_crCenter',
-    'pixelFlags_bad',
-    'pixelFlags_interpolated',
-    'pixelFlags_saturated',
-    'centroid_flag',
-    'apFlux_35_0_flag',
-]
-
-config.source_selector['science'].signalToNoise.fluxField = 'apFlux_35_0_instFlux'
-config.source_selector['science'].signalToNoise.errField = 'apFlux_35_0_instFluxErr'


### PR DESCRIPTION
Additionally, this adds some missing astrometry-related fields from the isolated star catalog for LATISS.