### PR TITLE
DM-45391: Add scripts to make baseline ComCam curated calibrations. 

### DIFF
--- a/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
+++ b/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
@@ -1,0 +1,133 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import re
+import os
+import dateutil.parser
+import numpy as np
+from lsst.afw.cameraGeom import DetectorType
+from lsst.meas.algorithms.simple_curve import AmpCurve
+from astropy.table import QTable
+
+import lsst.utils
+from lsst.obs.lsst import LsstComCam, LsstCam
+
+
+comcam_instr = LsstComCam()
+comcam_camera = comcam_instr.getCamera()
+lsst_camera = LsstCam().getCamera()
+
+data_root = lsst.utils.getPackageDir("obs_lsst_data")
+
+valid_start = "1970-01-01T00:00:00"
+valid_date = dateutil.parser.parse(valid_start)
+datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+
+# The LSSTComCam focal plane is a raft of ITL sensors, while the LSSTCam
+# focal plane is a mix of ITL and E2V sensors. While there are chromatic
+# QE variations from sensor to sensor, these are not as large as the
+# overall difference between the ITL family and the E2V family of
+# sensors. See, e.g., DM-40164. Therefore, the estimated LSSTComCam
+# transmission is taken as the average of all of the ITL amplifiers.
+transmission_sensor_files = []
+for det in lsst_camera:
+    if det.getType() != DetectorType.SCIENCE:
+        continue
+    if det.getPhysicalType() != "ITL":
+        # Skip non-ITL detectors.
+        continue
+
+    name = det.getName()
+
+    transmission_sensor_files.append(
+        os.path.join(data_root, "lsstCam", "transmission_sensor", name.lower(), f"{datestr}.ecsv"),
+    )
+
+# Read in the first one to get the size/shape of things.
+transmission_sensor0 = AmpCurve.readText(transmission_sensor_files[0])
+
+amp_names = sorted([amp.getName() for amp in comcam_camera[0]])
+
+wavelengths = transmission_sensor0.data[amp_names[0]][0]
+efficiencies = np.zeros((len(wavelengths), len(amp_names) * len(transmission_sensor_files)))
+
+counter = 0
+for transmission_sensor_file in transmission_sensor_files:
+    transmission_sensor = AmpCurve.readText(transmission_sensor_file)
+    for amp_name in amp_names:
+        wave, eff = transmission_sensor.data[amp_name]
+        if len(wave) != len(wavelengths):
+            # Ignore this amp which has fewer samples.
+            print(f"Skipping file {transmission_sensor_file} amplifier {amp_name}")
+            continue
+        np.testing.assert_array_almost_equal(np.asarray(wave), np.asarray(wavelengths))
+
+        efficiencies[:, counter] = eff
+        counter += 1
+
+print(f"Taking median of transmission from {counter} ITL amplifiers.")
+
+efficiency = np.median(efficiencies[:, : counter], axis=1)*transmission_sensor0.data[amp_names[0]][1].unit
+
+for det in comcam_camera:
+    name = det.getName()
+    raft, sensor = name.split("_")
+    det_num = det.getId()
+
+    curve_table = QTable(
+        {
+            "amp_name": np.repeat(amp_names, len(wavelengths)),
+            "wavelength": np.tile(wavelengths, len(amp_names)),
+            "efficiency": np.tile(efficiency, len(amp_names)),
+        }
+    )
+
+    curve = AmpCurve.fromTable(curve_table)
+
+    out_path = os.path.join(
+        comcam_instr.getObsDataPackageDir(),
+        comcam_instr.policyName,
+        "transmission_sensor",
+        name.lower(),
+    )
+    os.makedirs(out_path, exist_ok=True)
+    out_file = os.path.join(out_path, f"{datestr}.ecsv")
+
+    curve_table.meta.update(
+        {
+            "CALIBDATE": valid_start,
+            "INSTRUME": "ComCam",
+            "OBSTYPE": "transmission_sensor",
+            "TYPE": "transmission_sensor",
+            "DETECTOR": det_num,
+            "CALIBCLS": "lsst.ip.isr.IntermediateSensorTransmissionCurve",
+            "SOURCE": "Median of LSSTCam ITL sensor QE from DM-40164",
+        }
+    )
+    curve_table.meta["CALIB_ID"] = (
+        f"raftName={raft} detectorName={name} "
+        f"detector={det.getId()} calibDate={valid_start}"
+    )
+
+    # We need to remove any previous file if it is there.
+    if os.path.isfile(out_file):
+        os.remove(out_file)
+
+    curve.writeText(out_file)

--- a/python/lsst/obs/lsst/script/write_comcam_filter_files.py
+++ b/python/lsst/obs/lsst/script/write_comcam_filter_files.py
@@ -1,0 +1,108 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# This file is modeled after write_comCamSim_filter_files.py
+
+import os
+import re
+import numpy as np
+
+import astropy.units as u
+from astropy.table import QTable
+import dateutil.parser
+import galsim
+
+import lsst.utils
+from lsst.meas.algorithms.simple_curve import DetectorCurve
+from lsst.obs.lsst import LsstComCam
+
+
+valid_start = "1970-01-01T00:00:00"
+valid_date = dateutil.parser.parse(valid_start)
+datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+
+comcam_instr = LsstComCam()
+
+# Write initial transmission_filter files for the u, g, r, i, z, y bands
+# used by LSSTComCam.  These are the baseline/filter_[ugrizy].dat
+# files in the throughputs package.
+throughputs_dir = lsst.utils.getPackageDir("throughputs")
+filter_files = [
+    os.path.join(throughputs_dir, "baseline", _)
+    for _ in (
+        "filter_u.dat",
+        "filter_g.dat",
+        "filter_r.dat",
+        "filter_i.dat",
+        "filter_z.dat",
+        "filter_y.dat",
+    )
+]
+physical_filters = ("u_02", "g_01", "r_03", "i_06", "z_03", "y_04")
+
+for physical_filter, filter_file in zip(physical_filters, filter_files):
+    throughput = np.genfromtxt(filter_file).transpose()
+    # Use a GalSim.Bandpass object to truncate the curves at low
+    # relative throughput and thin the number of wavelength points.
+    bp = galsim.Bandpass(
+        galsim.LookupTable(*throughput, interpolant="linear"), wave_type="nm"
+    )
+    # We are going to be aggressive on out-of-band throughput for
+    # these reference filter curves.
+    bp = bp.truncate(relative_throughput=1e-3)
+    bp = bp.thin()
+
+    # Package as a DetectorCurve object.
+    optics_table = QTable(
+        {
+            "wavelength": bp.wave_list * u.nanometer,
+            "efficiency": bp(bp.wave_list) * 100.0 * u.percent,
+        }
+    )
+    curve = DetectorCurve.fromTable(optics_table)
+
+    # Set metadata values.
+    optics_table.meta.update(
+        {
+            "CALIBDATE": valid_start,
+            "INSTRUME": "ComCam",
+            "OBSTYPE": "transmission_filter",
+            "TYPE": "transmission_filter",
+            "CALIBCLS": "lsst.ip.isr.IntermediateFilterTransmissionCurve",
+            "SOURCE": "https://github.com/lsst/throughputs",
+            "FILTER": physical_filter,
+            "VERSION": 1.9,
+        }
+    )
+
+    optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter={physical_filter}"
+
+    # Write output transmission_filter file.
+    out_path = os.path.join(
+        comcam_instr.getObsDataPackageDir(),
+        comcam_instr.policyName,
+        "transmission_filter",
+        physical_filter,
+    )
+    os.makedirs(out_path, exist_ok=True)
+    out_file = os.path.join(out_path, f"{datestr}.ecsv")
+
+    curve.writeText(out_file)

--- a/python/lsst/obs/lsst/script/write_comcam_optics_file.py
+++ b/python/lsst/obs/lsst/script/write_comcam_optics_file.py
@@ -1,0 +1,102 @@
+# This file is part of obs_lsst.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# This file is modeled after write_comCamSim_optics_file.py
+
+import os
+import re
+import numpy as np
+
+import astropy.units as u
+from astropy.table import QTable
+import dateutil.parser
+import galsim
+
+import lsst.utils
+from lsst.meas.algorithms.simple_curve import DetectorCurve
+from lsst.obs.lsst import LsstComCam
+
+
+valid_start = "1970-01-01T00:00:00"
+valid_date = dateutil.parser.parse(valid_start)
+datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+
+comcam_instr = LsstComCam()
+
+# Obtain the throughputs of the individual optical components from
+# the throughputs package.
+throughputs_dir = lsst.utils.getPackageDir("throughputs")
+
+component_files = [
+    os.path.join(throughputs_dir, "baseline", _)
+    for _ in ("m1.dat", "m2.dat", "m3.dat", "lens1.dat", "lens2.dat", "lens3.dat")
+]
+
+# Combine, i.e., multiply, the component contributions to get the
+# total optical throughput.
+total = np.genfromtxt(component_files[0], names=["wl", "throughput"])
+for component_file in component_files[1:]:
+    component = np.genfromtxt(component_file, names=["wl", "throughput"])
+    total["throughput"] *= component["throughput"]
+
+# Use a GalSim.Bandpass object to truncate the curves at low
+# relative throughput and thin the number of wavelength points.
+bp = galsim.Bandpass(
+    galsim.LookupTable(total["wl"], total["throughput"], interpolant="linear"),
+    wave_type="nm",
+)
+bp = bp.truncate(relative_throughput=1e-4)
+bp = bp.thin()
+
+# Package as a DetectorCurve object.
+optics_table = QTable(
+    {
+        "wavelength": bp.wave_list * u.nanometer,
+        "efficiency": bp(bp.wave_list) * 100.0 * u.percent,
+    }
+)
+curve = DetectorCurve.fromTable(optics_table)
+
+# Set metadata values.
+optics_table.meta.update(
+    {
+        "CALIBDATE": valid_start,
+        "INSTRUME": "ComCam",
+        "OBSTYPE": "transmission_optics",
+        "TYPE": "transmission_optics",
+        "CALIBCLS": "lsst.ip.isr.IntermediateOpticsTransmissionCurve",
+        "SOURCE": "https://github.com/lsst/throughputs",
+        "VERSION": 1.9,
+    }
+)
+
+optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter=None"
+
+# Write output transmission_optics file.
+out_path = os.path.join(
+    comcam_instr.getObsDataPackageDir(),
+    comcam_instr.policyName,
+    "transmission_optics",
+)
+os.makedirs(out_path, exist_ok=True)
+out_file = os.path.join(out_path, f"{datestr}.ecsv")
+
+curve.writeText(out_file)


### PR DESCRIPTION
These are scripts to (a) average the ITL sensor QE curves; (b) make filter and optics transmission curves based on the official throughputs v1.9.