### PR TITLE
DM-47034: Convert effTime fiducials to electrons

### DIFF
--- a/config/comCam/fiducialSkyBackground.py
+++ b/config/comCam/fiducialSkyBackground.py
@@ -1,14 +1,12 @@
-# Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. Gain values derived from ComCam PTC
-# processed in u/jchiang/ptc_BLOCK-275_w_2024_28.
-# See DM-45333 for more details.
+# Fiducial values derived from skyCounts in syseng_throughput v1.9.
+# See DM-47034 for more details.
 
-# Fiducial SkyBackground in ADU per second
+# Fiducial SkyBackground in electrons per second
 config.fiducialSkyBackground = {
-    "u": 0.91,
-    "g": 9.35,
-    "r": 19.94,
-    "i": 32.04,
-    "z": 48.05,
-    "y": 54.81,
+    "u": 1.51,
+    "g": 15.45,
+    "r": 32.95,
+    "i": 52.94,
+    "z": 79.40,
+    "y": 90.57,
 }

--- a/config/comCam/fiducialZeroPoint.py
+++ b/config/comCam/fiducialZeroPoint.py
@@ -1,14 +1,12 @@
 # Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. Gain values derived from ComCam PTC
-# processed in u/jchiang/ptc_BLOCK-275_w_2024_28.
-# See DM-45333 for more details.
+# syseng_throughput v1.9. See DM-47034 for more details.
 
-# Fiducial ZeroPoint for 1s exposure
+# Fiducial ZeroPoint in electrons for 1s exposure
 config.fiducialZeroPoint = {
-    "u": 25.97,
-    "g": 27.96,
-    "r": 27.81,
-    "i": 27.62,
-    "z": 27.23,
-    "y": 26.27,
+    "u": 26.52,
+    "g": 28.51,
+    "r": 28.36,
+    "i": 28.17,
+    "z": 27.78,
+    "y": 26.82,
 }

--- a/config/comCamSim/fiducialSkyBackground.py
+++ b/config/comCamSim/fiducialSkyBackground.py
@@ -1,13 +1,12 @@
-# Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. See SMTN-002 (https://smtn-002.lsst.io) and DM-44855
-# for discussion.
+# Fiducial values derived from skyCounts in syseng_throughput v1.9.
+# See DM-47034 for more details.
 
-# Fiducial SkyBackground in ADU per second
+# Fiducial SkyBackground in electrons per second
 config.fiducialSkyBackground = {
-    "u": 0.90,
-    "g": 9.20,
-    "r": 19.62,
-    "i": 31.51,
-    "z": 47.26,
-    "y": 53.91,
+    "u": 1.51,
+    "g": 15.45,
+    "r": 32.95,
+    "i": 52.94,
+    "z": 79.40,
+    "y": 90.57,
 }

--- a/config/comCamSim/fiducialZeroPoint.py
+++ b/config/comCamSim/fiducialZeroPoint.py
@@ -1,13 +1,12 @@
 # Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. See SMTN-002 (https://smtn-002.lsst.io) and DM-44855
-# for discussion.
+# syseng_throughput v1.9. See DM-47034 for more details.
 
-# Fiducial ZeroPoint for 1s exposure
+# Fiducial ZeroPoint in electrons for 1s exposure
 config.fiducialZeroPoint = {
-    "u": 25.96,
-    "g": 27.95,
-    "r": 27.80,
-    "i": 27.61,
-    "z": 27.22,
-    "y": 26.26,
+    "u": 26.52,
+    "g": 28.51,
+    "r": 28.36,
+    "i": 28.17,
+    "z": 27.78,
+    "y": 26.82,
 }

--- a/config/lsstCam/fiducialSkyBackground.py
+++ b/config/lsstCam/fiducialSkyBackground.py
@@ -1,18 +1,12 @@
-# Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. Gain values derived from ComCam PTC
-# processed in u/jchiang/ptc_BLOCK-275_w_2024_28.
-# See DM-45333 for more details.
+# Fiducial values derived from skyCounts in syseng_throughput v1.9.
+# See DM-47034 for more details.
 
-# Note that we don’t have the real LSSTCam ones yet. As currently formulated,
-# the fiducials depend on the detector gains, and it hasn't been decided yet
-# how to "average" (or otherwise pick from) the detectors in LSSTCam.
-
-# Fiducial SkyBackground in ADU per second
+# Fiducial SkyBackground in electrons per second
 config.fiducialSkyBackground = {
-    "u": 0.91,
-    "g": 9.35,
-    "r": 19.94,
-    "i": 32.04,
-    "z": 48.05,
-    "y": 54.81,
+    "u": 1.51,
+    "g": 15.45,
+    "r": 32.95,
+    "i": 52.94,
+    "z": 79.40,
+    "y": 90.57,
 }

--- a/config/lsstCam/fiducialZeroPoint.py
+++ b/config/lsstCam/fiducialZeroPoint.py
@@ -1,18 +1,12 @@
 # Fiducial values derived from SMTN-002 (v2024-03-06), based on
-# syseng_throughput v1.9. Gain values derived from ComCam PTC
-# processed in u/jchiang/ptc_BLOCK-275_w_2024_28.
-# See DM-45333 for more details.
+# syseng_throughput v1.9. See DM-47034 for more details.
 
-# Note that we don’t have the real LSSTCam ones yet. As currently formulated,
-# the fiducials depend on the detector gains, and it hasn't been decided yet
-# how to "average" (or otherwise pick from) the detectors in LSSTCam.
-
-# Fiducial ZeroPoint for 1s exposure
+# Fiducial ZeroPoint in electrons for 1s exposure
 config.fiducialZeroPoint = {
-    "u": 25.97,
-    "g": 27.96,
-    "r": 27.81,
-    "i": 27.62,
-    "z": 27.23,
-    "y": 26.27,
+    "u": 26.52,
+    "g": 28.51,
+    "r": 28.36,
+    "i": 28.17,
+    "z": 27.78,
+    "y": 26.82,
 }


### PR DESCRIPTION
ComCam, ComCamSim and lsstCam will produce images in units of electrons. This means that the sky background and zeropoint values should be updated to be in units of electrons. This is actually the native unit of SMTN-002, so in many ways this is cleaner than what was being done before (which involved estimating and applying the gain). 