### PR TITLE
DM-47197: Turn on flat fielding and amp offsets for LSSTComCam.

### DIFF
--- a/config/comCam/isrLSST.py
+++ b/config/comCam/isrLSST.py
@@ -29,6 +29,10 @@ config.doSaturation = True
 config.crosstalk.doQuadraticCrosstalkCorrection = False
 config.doDeferredCharge = False
 
+config.doAmpOffset = True
+config.ampOffset.doApplyAmpOffset = True
+config.ampOffset.ampEdgeMaxOffset = 100.0
+
 overscanCamera = config.overscanCamera
 
 detectorConfig = copy.copy(overscanCamera.defaultDetectorConfig)

--- a/config/comCam/isrLSST.py
+++ b/config/comCam/isrLSST.py
@@ -28,7 +28,6 @@ import copy
 config.doSaturation = True
 config.crosstalk.doQuadraticCrosstalkCorrection = False
 config.doDeferredCharge = False
-config.doFlat = False
 
 overscanCamera = config.overscanCamera
 


### PR DESCRIPTION
We have usable flats for r and i now, so turn them on.

We also have some uncertainty for the gains, so turn on the amp offset code.