### PR TITLE
DM-47321: Fix and extend ImSim refcat configurations.

### DIFF
--- a/config/imsim/analysisToolsAstrometricCatalogMatch.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatch.py
@@ -21,5 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
-config.connections.refCat = "cal_ref_cat_2_2"
+config.connections.refCatalog = "cal_ref_cat_2_2"
 config.referenceCatalogLoader.refObjLoader.requireProperMotion = False

--- a/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
+++ b/config/imsim/analysisToolsAstrometricCatalogMatchVisit.py
@@ -21,5 +21,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 
 config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "lsst_g_smeared"
-config.connections.refCat = "cal_ref_cat_2_2"
+config.connections.refCatalog = "cal_ref_cat_2_2"
 config.referenceCatalogLoader.refObjLoader.requireProperMotion = False

--- a/config/imsim/analysisToolsCatalogMatch.py
+++ b/config/imsim/analysisToolsCatalogMatch.py
@@ -23,4 +23,4 @@
 """LSST-specific overrides for CatalogMatchTask"""
 
 config.anyFilterMapsToThis = "lsst_g_smeared"
-config.connections.refCat = "cal_ref_cat_2_2"
+config.connections.refCatalog = "cal_ref_cat_2_2"

--- a/config/imsim/analysisToolsCatalogMatchVisit.py
+++ b/config/imsim/analysisToolsCatalogMatchVisit.py
@@ -23,4 +23,4 @@
 """LSST-specific overrides for CatalogMatchVisitTask"""
 
 config.anyFilterMapsToThis = "lsst_g_smeared"
-config.connections.refCat = "cal_ref_cat_2_2"
+config.connections.refCatalog = "cal_ref_cat_2_2"

--- a/config/imsim/refCatObjectAnalysisTask.py
+++ b/config/imsim/refCatObjectAnalysisTask.py
@@ -1,0 +1,2 @@
+config.connections.refCatalog = "cal_ref_cat_2_2"
+config.connections.outputName = "objectTable_tract_cal_ref_cat_2_2_match_photom"

--- a/config/imsim/refCatSourceAnalysisTask.py
+++ b/config/imsim/refCatSourceAnalysisTask.py
@@ -1,0 +1,2 @@
+config.connections.refCatalog = "cal_ref_cat_2_2"
+config.connections.outputName = "sourceTable_visit_cal_ref_cat_2_2_match_photom"


### PR DESCRIPTION
The switch from 'refCat' to 'refCatalog' in some of these is a switch from the input connection configuration to a connection template that affects both that input and the output name.