### PR TITLE
Increase spacial order interpolation for PSF/Piff

### DIFF
--- a/config/comCam/finalize_characterization.py
+++ b/config/comCam/finalize_characterization.py
@@ -1,0 +1,4 @@
+# DM-48026: Order 2 does not looks to be enough
+# for spatial interpolation of the PSF. Order 3
+# remove most of spatial structure.
+config.psf_determiner['piff'].spatialOrder = 3


### PR DESCRIPTION
Based on first iteration if ComCam I can see that increasing spatial interpolation of PSF parameters from order 2 to order 3 it removes most of spatial structures in second moment of PSF second moment residuals.