### PR TITLE
DM-48887: Enable zeroth order interp if not enough stars.

### DIFF
--- a/config/comCam/finalize_characterization.py
+++ b/config/comCam/finalize_characterization.py
@@ -2,3 +2,5 @@
 # for spatial interpolation of the PSF. Order 4
 # remove most of spatial structure.
 config.psf_determiner['piff'].spatialOrder = 4
+# See DM-48887 for more detail.
+config.psf_determiner['piff'].zerothOrderInterpNotEnoughStars = True


### PR DESCRIPTION
More context in https://rubinobs.atlassian.net/browse/DM-48887.