### PR TITLE
DM-47181: Add gbdes config file for LSSTComCam

### DIFF
--- a/config/comCam/gbdesAstrometricFit.py
+++ b/config/comCam/gbdesAstrometricFit.py
@@ -1,0 +1,1 @@
+config.fitProperMotion = True


### PR DESCRIPTION
In the configurations of gbdes I am just enabling Proper Motion fitting right now. 