### PR TITLE
DM-49600: Remove star measurement CompensatedTophatFlux conf

### DIFF
--- a/config/latiss/calibrateImage.py
+++ b/config/latiss/calibrateImage.py
@@ -81,7 +81,7 @@ config.astrometry.matcher.maxRotationDeg = 2.0
 
 # Set the default aperture as appropriate for the LATISS plate scale.
 config.star_measurement.plugins["base_CircularApertureFlux"].radii = [35.0]
+config.star_measurement.plugins["base_CompensatedTophatFlux"].apertures = [35]
 config.star_measurement.slots.apFlux = "base_CircularApertureFlux_35_0"
 config.star_measurement.slots.calibFlux = "base_CircularApertureFlux_35_0"
-config.star_measurement.algorithms["base_CompensatedTophatFlux"].apertures = [35]
 config.star_normalized_calibration_flux.raw_calibflux_name = "base_CompensatedTophatFlux_35"


### PR DESCRIPTION
On DM-49600 it was discovered that the obs_lsst config overrides for the calibrateImage task in LATISS were not being picked up correctly due to a subsequent config override in `drp_pipe/config/calibrateImage.py`. Standing up a LATISS ingredients YAML and setting the appropriate config override there resolves this issue, as this file is last in the chain. We remove the offending config from obs_lsst to prevent possible future confusion as to it being set here.