### PR TITLE
DM-49673-v29: Add per-band spatialOrder config option in piff and add a minNPsfStar criterion for detector rejection

### DIFF
--- a/config/comCam/finalize_characterization.py
+++ b/config/comCam/finalize_characterization.py
@@ -1,7 +1,12 @@
-# DM-48093: Order 2 does not looks to be enough
-# for spatial interpolation of the PSF. Order 4
-# remove most of spatial structure.
-config.psf_determiner['piff'].spatialOrder = 4
+# See DM-49673 for more detail.
+config.psf_determiner['piff'].spatialOrderPerBand = {
+    "u": 2,
+    "g": 4,
+    "r": 4,
+    "i": 4,
+    "z": 4,
+    "y": 4,
+}
 # See DM-48887 for more detail.
 config.psf_determiner['piff'].zerothOrderInterpNotEnoughStars = True
 # See DM-49152 for more detail.


### PR DESCRIPTION
We now have the option to set a per-band config for the spatial order of the final PSF modle fit.  This sets our preferred overrides for LSSTComCam, which are motivated by the fact that u band will almost always have fewer PSF canditates than the other bands (throughput, stellar SED, etc.), and that u-band coadds are highly unlikely to be used in lensing/shear analyses. Setting a smaller spatial order for u precludes an attempt at a higher order fit that inevitably won't be well-constrained (and currently piff does not handle this internally and returns a dodgy PSF model).