### PR TITLE
DM-50063: Fix the max_exposure_id value to be historical value

### DIFF
--- a/python/lsst/obs/lsst/translators/lsst.py
+++ b/python/lsst/obs/lsst/translators/lsst.py
@@ -274,12 +274,15 @@ class LsstBaseTranslator(FitsTranslator):
         -------
         max_exposure_id : `int`
             The maximum value.
+
+        Notes
+        -----
+        The value is hard-coded to reflect historical values that were used
+        for various controllers before the sequence counter was unified.
         """
-        max_date = "2050-12-31T23:59.999"
-        max_seqnum = 99_999
-        # This controller triggers the largest numbers
-        max_controller = CONTROLLERS[-1]
-        return cls.compute_exposure_id(max_date, max_seqnum, max_controller)
+        # Assumes maximum observing date of 2050-12-31, 99,999 exposures per
+        # day and 6 controllers.
+        return 7050123199999
 
     @classmethod
     def detector_mapping(cls):

--- a/python/lsst/obs/lsst/translators/ts3.py
+++ b/python/lsst/obs/lsst/translators/ts3.py
@@ -177,3 +177,8 @@ class LsstTS3Translator(LsstBaseTranslator):
         serial = self.to_detector_serial()
         detector_info = self.compute_detector_info_from_serial(serial)
         return detector_info[0]
+
+    @classmethod
+    def max_exposure_id(cls):
+        # Only one controller by definition and only the date matters.
+        return cls.compute_exposure_id("2050-12-31T23:59.999")

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -174,6 +174,22 @@ class TestInstruments(unittest.TestCase):
         self.checkInstrumentWithRegistry(Latiss,
                                          "latiss/raw/2018-09-20/3018092000065-det000.fits")
 
+    def test_exposure_max(self):
+        # Ensure that the exposure max value does not change.
+        for cls, exp_max in (
+            (LsstCam, 7050123199999),
+            (LsstComCam, 7050123199999),
+            (LsstCamImSim, 9999999),
+            (LsstCamPhoSim, 9999999),
+            (LsstTS8, 205012312359999),
+            (LsstTS3, 205012312359999),
+            (LsstUCDCam, 7050123199999),
+            (Latiss, 7050123199999),
+            (LsstComCamSim, 7050123199999),
+            (LsstCamSim, 7050123199999),
+        ):
+            self.assertEqual(cls.translatorClass.max_exposure_id(), exp_max)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rather than derive from controller code we have to lock it into place to prevent churn in the dimension record definition.