### PR TITLE
DM-49900: Replace dateutil.parser with astropy Time

### DIFF
--- a/python/lsst/obs/lsst/script/rewrite_latiss_optics_file.py
+++ b/python/lsst/obs/lsst/script/rewrite_latiss_optics_file.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
-import re
-import dateutil.parser
 
 import numpy as np
 import astropy.units as u
@@ -29,6 +27,7 @@ from astropy.table import Table, QTable
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 
+from ..utils import valid_start_to_file_root
 
 data_dir = lsst.utils.getPackageDir("obs_lsst_data")
 subaru_file = "subaru_m1_r_20200219.txt"
@@ -59,8 +58,7 @@ optics_table["efficiency"] += 3.5*u.percent
 
 curve = DetectorCurve.fromTable(optics_table)
 
-valid_date = dateutil.parser.parse(valid_start)
-datestr = ''.join(re.split(r'[:-]', valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 outfile = os.path.join(data_dir, "latiss", "transmission_optics", datestr + ".ecsv")
 

--- a/python/lsst/obs/lsst/script/rewrite_latiss_optics_file.py
+++ b/python/lsst/obs/lsst/script/rewrite_latiss_optics_file.py
@@ -27,7 +27,7 @@ from astropy.table import Table, QTable
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 data_dir = lsst.utils.getPackageDir("obs_lsst_data")
 subaru_file = "subaru_m1_r_20200219.txt"
@@ -58,7 +58,7 @@ optics_table["efficiency"] += 3.5*u.percent
 
 curve = DetectorCurve.fromTable(optics_table)
 
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 outfile = os.path.join(data_dir, "latiss", "transmission_optics", datestr + ".ecsv")
 

--- a/python/lsst/obs/lsst/script/rewrite_latiss_qe_file.py
+++ b/python/lsst/obs/lsst/script/rewrite_latiss_qe_file.py
@@ -21,13 +21,13 @@
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import QTable
-import re
 import os
-import dateutil.parser
 import numpy
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
+
+from ..utils import valid_start_to_file_root
 
 amp_name_map = {'AMP01': 'C10', 'AMP02': 'C11', 'AMP03': 'C12', 'AMP04': 'C13', 'AMP05': 'C14',
                 'AMP06': 'C15', 'AMP07': 'C16', 'AMP08': 'C17', 'AMP09': 'C07', 'AMP10': 'C06',
@@ -93,8 +93,7 @@ filename = os.path.join(data_dir, "latiss", "transmission_sensor", raft_detector
 curve_table = convert_qe_curve(filename)
 curve = AmpCurve.fromTable(curve_table)
 
-valid_date = dateutil.parser.parse(valid_start)
-datestr = ''.join(re.split(r'[:-]', valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 outfile = os.path.join(data_dir, "latiss", "transmission_sensor", raft_detector, datestr + ".ecsv")
 

--- a/python/lsst/obs/lsst/script/rewrite_latiss_qe_file.py
+++ b/python/lsst/obs/lsst/script/rewrite_latiss_qe_file.py
@@ -27,7 +27,7 @@ import numpy
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 amp_name_map = {'AMP01': 'C10', 'AMP02': 'C11', 'AMP03': 'C12', 'AMP04': 'C13', 'AMP05': 'C14',
                 'AMP06': 'C15', 'AMP07': 'C16', 'AMP08': 'C17', 'AMP09': 'C07', 'AMP10': 'C06',
@@ -93,7 +93,7 @@ filename = os.path.join(data_dir, "latiss", "transmission_sensor", raft_detector
 curve_table = convert_qe_curve(filename)
 curve = AmpCurve.fromTable(curve_table)
 
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 outfile = os.path.join(data_dir, "latiss", "transmission_sensor", raft_detector, datestr + ".ecsv")
 

--- a/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-40164.py
+++ b/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-40164.py
@@ -36,7 +36,7 @@ import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
 import lsst.afw.math
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 
 class SplineFitter:
@@ -156,7 +156,7 @@ parquet_file_update = os.path.join(
 )
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 data = Table.read(parquet_file)
 

--- a/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-40164.py
+++ b/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-40164.py
@@ -26,9 +26,7 @@
 
 import astropy.units as u
 from astropy.table import Table, QTable
-import re
 import os
-import dateutil.parser
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.optimize import leastsq
@@ -37,6 +35,8 @@ import copy
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
 import lsst.afw.math
+
+from ..utils import valid_start_to_file_root
 
 
 class SplineFitter:
@@ -156,8 +156,7 @@ parquet_file_update = os.path.join(
 )
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = ''.join(re.split(r'[:-]', valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 data = Table.read(parquet_file)
 

--- a/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-49283.py
+++ b/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-49283.py
@@ -32,7 +32,7 @@ import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
 import lsst.afw.math
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 data_path = lsst.utils.getPackageDir("obs_lsst_data")
 transmission_path = os.path.join(data_path, "lsstCam", "transmission_sensor")
@@ -49,7 +49,7 @@ parquet_file_corr_factors = os.path.join(
 )
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 data_update = Table.read(parquet_file_update)
 

--- a/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-49283.py
+++ b/python/lsst/obs/lsst/script/rewrite_lsstcam_qe_files_DM-49283.py
@@ -25,15 +25,14 @@
 
 import astropy.units as u
 from astropy.table import Table, QTable
-import re
 import os
-import dateutil.parser
 import numpy as np
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import AmpCurve
 import lsst.afw.math
 
+from ..utils import valid_start_to_file_root
 
 data_path = lsst.utils.getPackageDir("obs_lsst_data")
 transmission_path = os.path.join(data_path, "lsstCam", "transmission_sensor")
@@ -50,8 +49,7 @@ parquet_file_corr_factors = os.path.join(
 )
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = ''.join(re.split(r'[:-]', valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 data_update = Table.read(parquet_file_update)
 

--- a/python/lsst/obs/lsst/script/rewrite_ts8_qe_files.py
+++ b/python/lsst/obs/lsst/script/rewrite_ts8_qe_files.py
@@ -25,15 +25,15 @@ from astropy.io import fits
 from astropy.table import QTable
 import argparse
 import sys
-import re
 import os
-import dateutil.parser
 import pickle
 import numpy
 
 from lsst.meas.algorithms.simple_curve import AmpCurve
 
 from lsst.obs.lsst import LsstTS8
+
+from ..utils import valid_start_to_file_root
 
 amp_name_map = {'AMP01': 'C10', 'AMP02': 'C11', 'AMP03': 'C12', 'AMP04': 'C13', 'AMP05': 'C14',
                 'AMP06': 'C15', 'AMP07': 'C16', 'AMP08': 'C17', 'AMP09': 'C07', 'AMP10': 'C06',
@@ -103,8 +103,7 @@ def rewrite_ts8_files(picklefile, out_root='.', valid_start='1970-01-01T00:00:00
     cam = ts8.getCamera()
     file_root = os.path.dirname(picklefile)
 
-    valid_date = dateutil.parser.parse(valid_start)
-    datestr = ''.join(re.split(r'[:-]', valid_date.isoformat()))
+    datestr = valid_start_to_file_root(valid_start)
 
     if not file_root:  # no path given
         file_root = os.path.curdir()

--- a/python/lsst/obs/lsst/script/rewrite_ts8_qe_files.py
+++ b/python/lsst/obs/lsst/script/rewrite_ts8_qe_files.py
@@ -33,7 +33,7 @@ from lsst.meas.algorithms.simple_curve import AmpCurve
 
 from lsst.obs.lsst import LsstTS8
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 amp_name_map = {'AMP01': 'C10', 'AMP02': 'C11', 'AMP03': 'C12', 'AMP04': 'C13', 'AMP05': 'C14',
                 'AMP06': 'C15', 'AMP07': 'C16', 'AMP08': 'C17', 'AMP09': 'C07', 'AMP10': 'C06',
@@ -103,7 +103,7 @@ def rewrite_ts8_files(picklefile, out_root='.', valid_start='1970-01-01T00:00:00
     cam = ts8.getCamera()
     file_root = os.path.dirname(picklefile)
 
-    datestr = valid_start_to_file_root(valid_start)
+    datestr = iso_date_to_curated_calib_file_root(valid_start)
 
     if not file_root:  # no path given
         file_root = os.path.curdir()

--- a/python/lsst/obs/lsst/script/write_comCamSim_filter_files.py
+++ b/python/lsst/obs/lsst/script/write_comCamSim_filter_files.py
@@ -19,16 +19,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
-import re
 import numpy as np
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
+
+from ..utils import valid_start_to_file_root
 
 # Write transmission_filter files for the g, r, i band used
 # by LSSTComCamSim.  These are the baseline/filter_[gri].dat
@@ -77,8 +77,7 @@ for physical_filter, filter_file in zip(physical_filters, filter_files):
     optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter={physical_filter}"
 
     # Write output transmission_filter file.
-    valid_date = dateutil.parser.parse(valid_start)
-    datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+    datestr = valid_start_to_file_root(valid_start)
 
     data_dir = lsst.utils.getPackageDir("obs_lsst_data")
     outfile = os.path.join(

--- a/python/lsst/obs/lsst/script/write_comCamSim_filter_files.py
+++ b/python/lsst/obs/lsst/script/write_comCamSim_filter_files.py
@@ -28,7 +28,7 @@ import galsim
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 # Write transmission_filter files for the g, r, i band used
 # by LSSTComCamSim.  These are the baseline/filter_[gri].dat
@@ -77,7 +77,7 @@ for physical_filter, filter_file in zip(physical_filters, filter_files):
     optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter={physical_filter}"
 
     # Write output transmission_filter file.
-    datestr = valid_start_to_file_root(valid_start)
+    datestr = iso_date_to_curated_calib_file_root(valid_start)
 
     data_dir = lsst.utils.getPackageDir("obs_lsst_data")
     outfile = os.path.join(

--- a/python/lsst/obs/lsst/script/write_comCamSim_optics_file.py
+++ b/python/lsst/obs/lsst/script/write_comCamSim_optics_file.py
@@ -19,16 +19,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
-import re
 import numpy as np
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
+
+from ..utils import valid_start_to_file_root
 
 # Obtain the throughputs of the individual optical components from
 # the throughputs package.
@@ -81,8 +81,7 @@ optics_table.meta.update(
 optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter=None"
 
 # Write output transmission_optics file.
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 data_dir = lsst.utils.getPackageDir("obs_lsst_data")
 outfile = os.path.join(data_dir, "comCamSim", "transmission_optics", datestr + ".ecsv")

--- a/python/lsst/obs/lsst/script/write_comCamSim_optics_file.py
+++ b/python/lsst/obs/lsst/script/write_comCamSim_optics_file.py
@@ -28,7 +28,7 @@ import galsim
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 # Obtain the throughputs of the individual optical components from
 # the throughputs package.
@@ -81,7 +81,7 @@ optics_table.meta.update(
 optics_table.meta["CALIB_ID"] = f"calibDate={valid_start} filter=None"
 
 # Write output transmission_optics file.
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 data_dir = lsst.utils.getPackageDir("obs_lsst_data")
 outfile = os.path.join(data_dir, "comCamSim", "transmission_optics", datestr + ".ecsv")

--- a/python/lsst/obs/lsst/script/write_comcam_estimated_non_linear_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_comcam_estimated_non_linear_crosstalk_coeffs.py
@@ -27,7 +27,7 @@ from lsst.ip.isr import CrosstalkCalib
 import lsst.utils
 from lsst.obs.lsst import LsstComCam, LsstCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 comcam_camera = LsstComCam().getCamera()
 lsst_camera = LsstCam().getCamera()
@@ -35,7 +35,7 @@ lsst_camera = LsstCam().getCamera()
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 # Get the crosstalk filenames of every ITL detector.
 crosstalk_files = []

--- a/python/lsst/obs/lsst/script/write_comcam_estimated_non_linear_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_comcam_estimated_non_linear_crosstalk_coeffs.py
@@ -18,9 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 import numpy as np
 import warnings
 from lsst.afw.cameraGeom import DetectorType
@@ -28,6 +27,7 @@ from lsst.ip.isr import CrosstalkCalib
 import lsst.utils
 from lsst.obs.lsst import LsstComCam, LsstCam
 
+from ..utils import valid_start_to_file_root
 
 comcam_camera = LsstComCam().getCamera()
 lsst_camera = LsstCam().getCamera()
@@ -35,8 +35,7 @@ lsst_camera = LsstCam().getCamera()
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 # Get the crosstalk filenames of every ITL detector.
 crosstalk_files = []

--- a/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
+++ b/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
@@ -18,9 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 import numpy as np
 from lsst.afw.cameraGeom import DetectorType
 from lsst.meas.algorithms.simple_curve import AmpCurve
@@ -29,6 +28,7 @@ from astropy.table import QTable
 import lsst.utils
 from lsst.obs.lsst import LsstComCam, LsstCam
 
+from ..utils import valid_start_to_file_root
 
 comcam_instr = LsstComCam()
 comcam_camera = comcam_instr.getCamera()
@@ -37,8 +37,7 @@ lsst_camera = LsstCam().getCamera()
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 # The LSSTComCam focal plane is a raft of ITL sensors, while the LSSTCam
 # focal plane is a mix of ITL and E2V sensors. While there are chromatic

--- a/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
+++ b/python/lsst/obs/lsst/script/write_comcam_estimated_transmission_sensor.py
@@ -28,7 +28,7 @@ from astropy.table import QTable
 import lsst.utils
 from lsst.obs.lsst import LsstComCam, LsstCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 comcam_instr = LsstComCam()
 comcam_camera = comcam_instr.getCamera()
@@ -37,7 +37,7 @@ lsst_camera = LsstCam().getCamera()
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 # The LSSTComCam focal plane is a raft of ITL sensors, while the LSSTCam
 # focal plane is a mix of ITL and E2V sensors. While there are chromatic

--- a/python/lsst/obs/lsst/script/write_comcam_filter_files.py
+++ b/python/lsst/obs/lsst/script/write_comcam_filter_files.py
@@ -22,22 +22,21 @@
 # This file is modeled after write_comCamSim_filter_files.py
 
 import os
-import re
 import numpy as np
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
+
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstComCam
+from ..utils import valid_start_to_file_root
 
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 comcam_instr = LsstComCam()
 

--- a/python/lsst/obs/lsst/script/write_comcam_filter_files.py
+++ b/python/lsst/obs/lsst/script/write_comcam_filter_files.py
@@ -32,11 +32,11 @@ import galsim
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstComCam
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 comcam_instr = LsstComCam()
 

--- a/python/lsst/obs/lsst/script/write_comcam_manual_defects.py
+++ b/python/lsst/obs/lsst/script/write_comcam_manual_defects.py
@@ -18,22 +18,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 from lsst.ip.isr import Defects
 from lsst.geom import Box2I, Point2I, Extent2I
 import lsst.utils
 from lsst.obs.lsst import LsstComCam
 
+from ..utils import valid_start_to_file_root
 
 camera = LsstComCam().getCamera()
 
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 for det in camera:
     print("Building manual defects from detector ", det.getName(), det.getId())

--- a/python/lsst/obs/lsst/script/write_comcam_manual_defects.py
+++ b/python/lsst/obs/lsst/script/write_comcam_manual_defects.py
@@ -25,14 +25,14 @@ from lsst.geom import Box2I, Point2I, Extent2I
 import lsst.utils
 from lsst.obs.lsst import LsstComCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 camera = LsstComCam().getCamera()
 
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 for det in camera:
     print("Building manual defects from detector ", det.getName(), det.getId())

--- a/python/lsst/obs/lsst/script/write_comcam_optics_file.py
+++ b/python/lsst/obs/lsst/script/write_comcam_optics_file.py
@@ -22,22 +22,20 @@
 # This file is modeled after write_comCamSim_optics_file.py
 
 import os
-import re
 import numpy as np
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstComCam
 
+from ..utils import valid_start_to_file_root
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 comcam_instr = LsstComCam()
 

--- a/python/lsst/obs/lsst/script/write_comcam_optics_file.py
+++ b/python/lsst/obs/lsst/script/write_comcam_optics_file.py
@@ -32,10 +32,10 @@ import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstComCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 comcam_instr = LsstComCam()
 

--- a/python/lsst/obs/lsst/script/write_latiss_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_latiss_crosstalk_coeffs.py
@@ -23,7 +23,7 @@ import os
 from lsst.daf.butler import Butler
 import lsst.utils
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 crosstalk_run = "u/czw/DM-37819/crosstalkGen.20230601a/20230601T201929Z"
 
@@ -37,7 +37,7 @@ name = det.getName()
 
 # Make this valid for all time.
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 directory = lsst.utils.getPackageDir("obs_lsst_data")
 out_path = os.path.join(directory, "latiss", "crosstalk", name.lower())
 os.makedirs(out_path, exist_ok=True)

--- a/python/lsst/obs/lsst/script/write_latiss_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_latiss_crosstalk_coeffs.py
@@ -18,12 +18,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 from lsst.daf.butler import Butler
 import lsst.utils
 
+from ..utils import valid_start_to_file_root
 
 crosstalk_run = "u/czw/DM-37819/crosstalkGen.20230601a/20230601T201929Z"
 
@@ -37,8 +37,7 @@ name = det.getName()
 
 # Make this valid for all time.
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 directory = lsst.utils.getPackageDir("obs_lsst_data")
 out_path = os.path.join(directory, "latiss", "crosstalk", name.lower())
 os.makedirs(out_path, exist_ok=True)

--- a/python/lsst/obs/lsst/script/write_lsstcam_manual_defects.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_manual_defects.py
@@ -18,22 +18,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 from lsst.ip.isr import Defects
 from lsst.geom import Box2I, Point2I, Extent2I
 import lsst.utils
 from lsst.obs.lsst import LsstCam
 
+from ..utils import valid_start_to_file_root
 
 camera = LsstCam().getCamera()
 
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 total_masked_pixels = 0
 

--- a/python/lsst/obs/lsst/script/write_lsstcam_manual_defects.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_manual_defects.py
@@ -25,14 +25,14 @@ from lsst.geom import Box2I, Point2I, Extent2I
 import lsst.utils
 from lsst.obs.lsst import LsstCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 camera = LsstCam().getCamera()
 
 data_root = lsst.utils.getPackageDir("obs_lsst_data")
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 total_masked_pixels = 0
 

--- a/python/lsst/obs/lsst/script/write_lsstcam_transmission_filter_detector.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_transmission_filter_detector.py
@@ -32,10 +32,10 @@ import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 lsstcam_instr = LsstCam()
 camera = lsstcam_instr.getCamera()

--- a/python/lsst/obs/lsst/script/write_lsstcam_transmission_filter_detector.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_transmission_filter_detector.py
@@ -20,23 +20,22 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-import re
+
 import numpy as np
 import fitsio
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstCam
 
+from ..utils import valid_start_to_file_root
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 lsstcam_instr = LsstCam()
 camera = lsstcam_instr.getCamera()

--- a/python/lsst/obs/lsst/script/write_lsstcam_transmission_optics.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_transmission_optics.py
@@ -22,22 +22,21 @@
 # This file is modeled after write_comcam_optics_file.py
 
 import os
-import re
+
 import numpy as np
 
 import astropy.units as u
 from astropy.table import QTable
-import dateutil.parser
 import galsim
 
 import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstCam
 
+from ..utils import valid_start_to_file_root
 
 valid_start = "1970-01-01T00:00:00"
-valid_date = dateutil.parser.parse(valid_start)
-datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+datestr = valid_start_to_file_root(valid_start)
 
 lsstcam_instr = LsstCam()
 

--- a/python/lsst/obs/lsst/script/write_lsstcam_transmission_optics.py
+++ b/python/lsst/obs/lsst/script/write_lsstcam_transmission_optics.py
@@ -33,10 +33,10 @@ import lsst.utils
 from lsst.meas.algorithms.simple_curve import DetectorCurve
 from lsst.obs.lsst import LsstCam
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 valid_start = "1970-01-01T00:00:00"
-datestr = valid_start_to_file_root(valid_start)
+datestr = iso_date_to_curated_calib_file_root(valid_start)
 
 lsstcam_instr = LsstCam()
 

--- a/python/lsst/obs/lsst/script/write_non_linear_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_non_linear_crosstalk_coeffs.py
@@ -27,7 +27,7 @@ import lsst.utils
 import warnings
 from scipy.stats import median_abs_deviation
 
-from ..utils import valid_start_to_file_root
+from lsst.obs.base.utils import iso_date_to_curated_calib_file_root
 
 repo = "/sdf/group/rubin/repo/main"
 butler = Butler(repo)
@@ -297,7 +297,7 @@ for detector in camera:
 
     # Save the ecsv files
     valid_start = "1970-01-01T00:00:00"
-    datestr = valid_start_to_file_root(valid_start)
+    datestr = iso_date_to_curated_calib_file_root(valid_start)
     directory = lsst.utils.getPackageDir("obs_lsst_data")
     out_path = os.path.join(directory, "lsstCam", "crosstalk", det_name.lower())
     os.makedirs(out_path, exist_ok=True)

--- a/python/lsst/obs/lsst/script/write_non_linear_crosstalk_coeffs.py
+++ b/python/lsst/obs/lsst/script/write_non_linear_crosstalk_coeffs.py
@@ -18,15 +18,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import re
 import os
-import dateutil.parser
+
 import numpy as np
 from lsst.daf.butler import Butler
 from lsst.ip.isr import CrosstalkCalib
 import lsst.utils
 import warnings
 from scipy.stats import median_abs_deviation
+
+from ..utils import valid_start_to_file_root
 
 repo = "/sdf/group/rubin/repo/main"
 butler = Butler(repo)
@@ -296,8 +297,7 @@ for detector in camera:
 
     # Save the ecsv files
     valid_start = "1970-01-01T00:00:00"
-    valid_date = dateutil.parser.parse(valid_start)
-    datestr = "".join(re.split(r"[:-]", valid_date.isoformat()))
+    datestr = valid_start_to_file_root(valid_start)
     directory = lsst.utils.getPackageDir("obs_lsst_data")
     out_path = os.path.join(directory, "lsstCam", "crosstalk", det_name.lower())
     os.makedirs(out_path, exist_ok=True)

--- a/python/lsst/obs/lsst/utils.py
+++ b/python/lsst/obs/lsst/utils.py
@@ -25,7 +25,10 @@
 Miscellaneous utilities related to lsst cameras
 """
 
-__all__ = ("readRawFile",)
+__all__ = ("readRawFile", "valid_start_to_file_root")
+
+import re
+from astropy.time import Time
 
 from .assembly import attachRawWcsFromBoresight, readRawAmps, fixAmpsAndAssemble
 from ._fitsHeader import readRawFitsHeader
@@ -57,3 +60,24 @@ def readRawFile(fileName, detector, dataId=None):
     exp.setMetadata(md)
     attachRawWcsFromBoresight(exp, dataId)
     return exp
+
+
+def valid_start_to_file_root(valid_start: str) -> str:
+    """Parse a calibration valid start time and convert to form suitable for
+    use in a filename.
+
+    Parameters
+    ----------
+    valid_start : `str`
+        Validity start time in ISOT format.
+
+    Returns
+    -------
+    date_str : `str`
+        Form suitable for use in a file name: YYYYMMDDTHHMMSS.
+    """
+    # Parse the ISO string to ensure conformity if there is an edit to
+    # valid_start.
+    format = "isot" if "T" in valid_start else "iso"
+    valid_date = Time(valid_start, format=format, scale="utc", precision=0)
+    return re.sub(r"\W", "", valid_date.isot)

--- a/python/lsst/obs/lsst/utils.py
+++ b/python/lsst/obs/lsst/utils.py
@@ -25,10 +25,7 @@
 Miscellaneous utilities related to lsst cameras
 """
 
-__all__ = ("readRawFile", "valid_start_to_file_root")
-
-import re
-from astropy.time import Time
+__all__ = ("readRawFile",)
 
 from .assembly import attachRawWcsFromBoresight, readRawAmps, fixAmpsAndAssemble
 from ._fitsHeader import readRawFitsHeader
@@ -60,24 +57,3 @@ def readRawFile(fileName, detector, dataId=None):
     exp.setMetadata(md)
     attachRawWcsFromBoresight(exp, dataId)
     return exp
-
-
-def valid_start_to_file_root(valid_start: str) -> str:
-    """Parse a calibration valid start time and convert to form suitable for
-    use in a filename.
-
-    Parameters
-    ----------
-    valid_start : `str`
-        Validity start time in ISOT format.
-
-    Returns
-    -------
-    date_str : `str`
-        Form suitable for use in a file name: YYYYMMDDTHHMMSS.
-    """
-    # Parse the ISO string to ensure conformity if there is an edit to
-    # valid_start.
-    format = "isot" if "T" in valid_start else "iso"
-    valid_date = Time(valid_start, format=format, scale="utc", precision=0)
-    return re.sub(r"\W", "", valid_date.isot)


### PR DESCRIPTION
We are always using ISO format strings so there is no benefit to using dateutil's advanced heuristics for the date parsing.

Requires lsst/obs_base#515