### PR TITLE
DM-50625: ComCamSim can't pass minimum voltage check

### DIFF
--- a/config/comCamSim/isrLSST.py
+++ b/config/comCamSim/isrLSST.py
@@ -26,3 +26,4 @@ config.doCrosstalk = False
 config.doLinearize = False
 config.doDeferredCharge = False
 config.doDefect = False
+config.bssVoltageMinimum = 0  # Simulated voltages are very low


### PR DESCRIPTION
This PR turns off ISR's minimum voltage check for `ComCamSim`, where it's not applicable.