### PR TITLE
DM-51841: Add fiducial m5 for lsstCam

### DIFF
--- a/config/lsstCam/computeExposureSummaryStats.py
+++ b/config/lsstCam/computeExposureSummaryStats.py
@@ -1,3 +1,4 @@
 config.load("fiducialPsfSigma.py")
 config.load("fiducialSkyBackground.py")
 config.load("fiducialZeroPoint.py")
+config.load("fiducialMagLim.py")

--- a/config/lsstCam/fiducialMagLim.py
+++ b/config/lsstCam/fiducialMagLim.py
@@ -1,0 +1,13 @@
+# Fiducial values derived from SMTN-002 (v2025-07-16), based on
+# syseng_throughput v1.9.
+# See DM-51841 for more details.
+
+# Fiducial SNR=5 magnitude limit for point-like sources.
+config.fiducialMagLim = {
+    "u": 23.70,
+    "g": 24.97,
+    "r": 24.52,
+    "i": 24.13,
+    "z": 23.56,
+    "y": 22.55,
+}

--- a/tests/test_lsstCam.py
+++ b/tests/test_lsstCam.py
@@ -109,10 +109,10 @@ class TestLsstCam(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
         md = self.butler.get('raw.metadata', dataId)
         self.assertEqual(md["TELESCOP"], "LSST")
 
-    def testFiducialMagLim(self):
-        """Verify that the fiducial m5 magnitude limit values match those given
-        in SMTN-002 (v.2025-07-16). The fiducial values must remain fixed so
-        that the effective time can be meaningfully interpreted.
+    def testFiducials(self):
+        """Verify that the fiducial values match those given in SMTN-002
+        (v.2025-07-16). The fiducial values must remain fixed so that
+        the effective time can be meaningfully interpreted.
         """
         from lsst.pipe.tasks.computeExposureSummaryStats import ComputeExposureSummaryStatsTask
         from lsst.pipe.tasks.computeExposureSummaryStats import ComputeExposureSummaryStatsConfig
@@ -133,9 +133,25 @@ class TestLsstCam(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
         for band, magLim in fiducialMagLim.items():
             msg = "The fiducialMagLim cannot be changed from SMTN-002 values without breaking "
             msg += "the calculation of effective time."
-            self.assertFloatsAlmostEqual(magLim, config.fiducialMagLim[band], atol=1e-3, rtol=1e-5,
-                                         err_msg=msg)
+            self.assertFloatsAlmostEqual(magLim, config.fiducialMagLim[band],
+                                         atol=1e-3, rtol=1e-5, msg=msg)
             print(magLim, config.fiducialMagLim[band])
+
+        # From SMTN-002. Changes would break the utility of effective_time.
+        fiducialExpTime = {
+            "u": 30.0,
+            "g": 30.0,
+            "r": 30.0,
+            "i": 30.0,
+            "z": 30.0,
+            "y": 30.0,
+        }
+        for band, expTime in fiducialExpTime.items():
+            msg = "The fiducialExpTime cannot be changed from SMTN-002 values without breaking "
+            msg += "the calculation of effective time."
+            self.assertFloatsAlmostEqual(expTime, config.fiducialExpTime[band],
+                                         atol=1e-3, rtol=1e-5, msg=msg)
+            print(expTime, config.fiducialExpTime[band])
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_lsstCam.py
+++ b/tests/test_lsstCam.py
@@ -109,6 +109,33 @@ class TestLsstCam(ObsLsstObsBaseOverrides, ObsLsstButlerTests):
         md = self.butler.get('raw.metadata', dataId)
         self.assertEqual(md["TELESCOP"], "LSST")
 
+    def testFiducialMagLim(self):
+        """Verify that the fiducial m5 magnitude limit values match those given
+        in SMTN-002 (v.2025-07-16). The fiducial values must remain fixed so
+        that the effective time can be meaningfully interpreted.
+        """
+        from lsst.pipe.tasks.computeExposureSummaryStats import ComputeExposureSummaryStatsTask
+        from lsst.pipe.tasks.computeExposureSummaryStats import ComputeExposureSummaryStatsConfig
+
+        instrument = self.getInstrument()
+        config = ComputeExposureSummaryStatsConfig()
+        instrument.applyConfigOverrides(ComputeExposureSummaryStatsTask._DefaultName, config)
+
+        # From SMTN-002. Changes would break the utility of effective_time.
+        fiducialMagLim = {
+            "u": 23.70,
+            "g": 24.97,
+            "r": 24.52,
+            "i": 24.13,
+            "z": 23.56,
+            "y": 22.55,
+        }
+        for band, magLim in fiducialMagLim.items():
+            msg = "The fiducialMagLim cannot be changed from SMTN-002 values without breaking "
+            msg += "the calculation of effective time."
+            self.assertFloatsAlmostEqual(magLim, config.fiducialMagLim[band], atol=1e-3, rtol=1e-5,
+                                         err_msg=msg)
+            print(magLim, config.fiducialMagLim[band])
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
Adding a fiducial m5 is necessary for calculating the effective time.