### PR TITLE
DM-54607: It does not look like LSSTCam has keywordsToCompare set in ISR

### DIFF
--- a/config/lsstCam/isrLSST.py
+++ b/config/lsstCam/isrLSST.py
@@ -30,6 +30,8 @@ config.badAmps = [
     "R03_S11_C00",  # Dead amp
 ]
 
+config.cameraKeywordsToCompare = ["SEQNAME", "SEQFILE", "SEQCKSUM", "ODP", "AP0_RC"]
+
 config.crosstalk.doQuadraticCrosstalkCorrection = True
 config.crosstalk.doSubtrahendMasking = True
 config.crosstalk.minPixelToMask = 1.0


### PR DESCRIPTION
Add cameraKeywordsToCompare for LSSTCam.